### PR TITLE
feat/BU-122: 로그인 API 구현

### DIFF
--- a/.claude/ERD.md
+++ b/.claude/ERD.md
@@ -82,6 +82,8 @@ Build-Up Platform 데이터베이스 구조 설계 문서입니다.
 | `email` | VARCHAR(100) | NULL | 이메일 |
 | `secret_key` | VARCHAR(100) | NULL | 인증용 시크릿키 |
 | `role_id` | BIGINT | FK, NULLABLE | 역할 (계약 시 할당) |
+| `refresh_token` | VARCHAR(500) | NULL | Refresh Token (JWT) |
+| `refresh_token_expires_at` | DATETIME | NULL | Refresh Token 만료 시간 |
 | `created_at` | DATETIME | DEFAULT now() | 생성 일시 |
 | `updated_at` | DATETIME | DEFAULT now() | 수정 일시 |
 
@@ -812,5 +814,6 @@ ON work_reports(work_report_status);
 | 2025-11-05 | attendances, payrolls 테이블 resident_num 컬럼 타입 변경 (VARCHAR(20)→500) 및 암호화 정책 통일 | 김세원 |
 | 2025-11-06 | roles 테이블 updated_at 컬럼 추가 | 김세원 |
 | 2025-11-06 | sites 테이블 manager_secret_key, employee_secret_key, secret_key_expires_at 컬럼 추가 (현장 관리자 회원가입 기능) | 김세원 |
+| 2025-11-07 | users 테이블 refresh_token, refresh_token_expires_at 컬럼 추가 (로그인 API 구현) | 김세원 |
 
 ---

--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -161,4 +161,31 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response, "현장 관리자 회원가입이 완료되었습니다"));
     }
+
+    /**
+     * 로그인 API
+     *
+     * <p>근로자, 현장 관리자, 기업 관리자 공통 로그인 API입니다.</p>
+     * <p>Access Token은 응답 Body에, Refresh Token은 HttpOnly 쿠키로 전달됩니다.</p>
+     *
+     * @param request 로그인 요청 정보
+     * @return LoginResponse - Access Token과 사용자 정보
+     */
+    @Operation(
+            summary = "로그인",
+            description = "근로자, 현장 관리자, 기업 관리자 공통 로그인 API입니다. " +
+                    "Access Token은 응답 Body에 포함되며, Refresh Token은 HttpOnly 쿠키로 전달됩니다."
+    )
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request
+    ) {
+        log.info("로그인 API 호출: username={}", request.getUsername());
+
+        LoginResponse response = authService.login(request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "로그인 성공")
+        );
+    }
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -6,6 +6,8 @@ import com.concrete.buildup.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -169,6 +171,7 @@ public class AuthController {
      * <p>Access Token은 응답 Body에, Refresh Token은 HttpOnly 쿠키로 전달됩니다.</p>
      *
      * @param request 로그인 요청 정보
+     * @param response HTTP 응답 (쿠키 설정용)
      * @return LoginResponse - Access Token과 사용자 정보
      */
     @Operation(
@@ -178,14 +181,26 @@ public class AuthController {
     )
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
-            @Valid @RequestBody LoginRequest request
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
     ) {
         log.info("로그인 API 호출: username={}", request.getUsername());
 
-        LoginResponse response = authService.login(request);
+        // 로그인 처리
+        LoginResult loginResult = authService.login(request);
+
+        // Refresh Token을 HttpOnly 쿠키로 설정
+        Cookie refreshTokenCookie = new Cookie("refreshToken", loginResult.getRefreshToken());
+        refreshTokenCookie.setHttpOnly(true);  // XSS 공격 방어
+        refreshTokenCookie.setSecure(true);     // HTTPS에서만 전송
+        refreshTokenCookie.setPath("/");        // 모든 경로에서 접근 가능
+        refreshTokenCookie.setMaxAge(loginResult.getRefreshTokenMaxAge().intValue());  // 만료 시간 설정
+        response.addCookie(refreshTokenCookie);
+
+        log.debug("Refresh Token 쿠키 설정 완료: maxAge={}초", loginResult.getRefreshTokenMaxAge());
 
         return ResponseEntity.ok(
-                ApiResponse.success(response, "로그인 성공")
+                ApiResponse.success(loginResult.getLoginResponse(), "로그인 성공")
         );
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,33 @@
+package com.concrete.buildup.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 로그인 요청 DTO
+ *
+ * <p>사용자 로그인 정보를 담는 DTO입니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "로그인 요청")
+public class LoginRequest {
+
+    @NotBlank(message = "아이디는 필수입니다")
+    @Schema(description = "로그인 ID", example = "testuser001", required = true)
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Schema(description = "비밀번호", example = "Test123@@", required = true)
+    private String password;
+
+    @Builder.Default
+    @Schema(description = "자동 로그인 여부 (true: 30일, false: 7일)", example = "false", required = false)
+    private Boolean rememberMe = false;
+}

--- a/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,36 @@
+package com.concrete.buildup.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 응답 DTO
+ *
+ * <p>로그인 성공 시 Access Token과 사용자 정보를 반환합니다.</p>
+ * <p>Refresh Token은 HttpOnly 쿠키로 전달됩니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "로그인 응답")
+public class LoginResponse {
+
+    @Schema(description = "Access Token (JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "사용자 ID", example = "testuser001")
+    private String userId;
+
+    @Schema(description = "사용자 역할 (EMPLOYEE, MANAGER, ADMIN)", example = "EMPLOYEE")
+    private String role;
+
+    @Schema(description = "Access Token 만료 시간 (초)", example = "3600")
+    private Long expiresIn;
+}

--- a/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResult.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResult.java
@@ -1,0 +1,37 @@
+package com.concrete.buildup.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 결과 내부 DTO
+ *
+ * <p>Service와 Controller 간의 데이터 전달용 내부 DTO입니다.</p>
+ * <p>API 응답에는 loginResponse만 포함되고, refreshToken은 HttpOnly 쿠키로 전달됩니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResult {
+
+    /**
+     * 로그인 응답 (API Body로 전달)
+     */
+    private LoginResponse loginResponse;
+
+    /**
+     * Refresh Token (HttpOnly 쿠키로 전달, 평문)
+     */
+    private String refreshToken;
+
+    /**
+     * Refresh Token 만료 시간 (초)
+     */
+    private Long refreshTokenMaxAge;
+}

--- a/src/main/java/com/concrete/buildup/domain/auth/entity/User.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/entity/User.java
@@ -81,6 +81,18 @@ public class User extends BaseEntity {
     private Boolean profileCompleted = false;
 
     /**
+     * Refresh Token
+     */
+    @Column(name = "refresh_token", length = 500)
+    private String refreshToken;
+
+    /**
+     * Refresh Token 만료 시간
+     */
+    @Column(name = "refresh_token_expires_at")
+    private LocalDateTime refreshTokenExpiresAt;
+
+    /**
      * 비밀번호 변경
      */
     public void updatePassword(String newPassword) {
@@ -129,5 +141,21 @@ public class User extends BaseEntity {
         this.profileCompleted = true;
         this.profileToken = null;
         this.profileTokenExpiresAt = null;
+    }
+
+    /**
+     * Refresh Token 업데이트
+     */
+    public void updateRefreshToken(String refreshToken, LocalDateTime expiresAt) {
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpiresAt = expiresAt;
+    }
+
+    /**
+     * Refresh Token 제거
+     */
+    public void clearRefreshToken() {
+        this.refreshToken = null;
+        this.refreshTokenExpiresAt = null;
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -23,7 +23,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.HexFormat;
 import java.util.UUID;
 
 /**
@@ -492,10 +496,10 @@ public class AuthService {
      * 로그인
      *
      * @param request 로그인 요청 정보
-     * @return LoginResponse - Access Token과 사용자 정보
+     * @return LoginResult - Access Token, 사용자 정보, Refresh Token
      */
     @Transactional
-    public LoginResponse login(LoginRequest request) {
+    public LoginResult login(LoginRequest request) {
         log.info("로그인 시도: username={}", request.getUsername());
 
         // 1. userId로 User 조회 (Fetch Join으로 Role도 함께 조회)
@@ -523,22 +527,50 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId(), rememberMe);
         log.debug("Refresh Token 생성 완료: userId={}, rememberMe={}", user.getUserId(), rememberMe);
 
-        // 5. Refresh Token을 DB에 저장
+        // 5. Refresh Token을 SHA-256으로 해시하여 DB에 저장
+        String hashedRefreshToken = hashToken(refreshToken);
         long expiration = rememberMe ? refreshTokenRememberMeExpiration : refreshTokenExpiration;
         LocalDateTime refreshTokenExpiresAt = LocalDateTime.now().plusSeconds(expiration / 1000);
-        user.updateRefreshToken(refreshToken, refreshTokenExpiresAt);
-        log.debug("Refresh Token DB 저장 완료: userId={}", user.getUserId());
+        user.updateRefreshToken(hashedRefreshToken, refreshTokenExpiresAt);
+        log.debug("Refresh Token 해시 후 DB 저장 완료: userId={}", user.getUserId());
 
         // 6. Response 생성
-        LoginResponse response = LoginResponse.builder()
+        LoginResponse loginResponse = LoginResponse.builder()
                 .accessToken(accessToken)
                 .userId(user.getUserId())
                 .role(user.getRole().getRoleName())
                 .expiresIn(accessTokenExpiration / 1000)  // 초 단위로 변환
                 .build();
 
+        // 7. LoginResult 생성 (refreshToken 포함, 평문)
+        LoginResult result = LoginResult.builder()
+                .loginResponse(loginResponse)
+                .refreshToken(refreshToken)  // 평문 토큰 (쿠키로 전달용)
+                .refreshTokenMaxAge(expiration / 1000)  // 초 단위로 변환
+                .build();
+
         log.info("로그인 성공: userId={}, role={}", user.getUserId(), user.getRole().getRoleName());
 
-        return response;
+        return result;
+    }
+
+    /**
+     * 토큰을 SHA-256으로 해시 처리
+     *
+     * <p>Refresh Token을 DB에 안전하게 저장하기 위해 SHA-256으로 해시합니다.</p>
+     * <p>DB 해킹 시에도 원본 토큰을 알 수 없도록 보호합니다.</p>
+     *
+     * @param token 원본 토큰
+     * @return SHA-256 해시값 (Hex 형식)
+     */
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("SHA-256 알고리즘을 찾을 수 없습니다", e);
+            throw new RuntimeException("토큰 해시 처리 중 오류 발생", e);
+        }
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -15,8 +15,10 @@ import com.concrete.buildup.global.exception.BusinessException;
 import com.concrete.buildup.global.exception.errorcode.AuthErrorCode;
 import com.concrete.buildup.global.exception.errorcode.SiteErrorCode;
 import com.concrete.buildup.global.util.AesEncryptionUtil;
+import com.concrete.buildup.global.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +47,16 @@ public class AuthService {
     private final SiteRepository siteRepository;
     private final PasswordEncoder passwordEncoder;
     private final AesEncryptionUtil aesEncryptionUtil;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    @Value("${jwt.refresh-token-remember-me-expiration}")
+    private long refreshTokenRememberMeExpiration;
 
     /**
      * 아이디 중복 확인
@@ -474,5 +486,59 @@ public class AuthService {
                 .verificationRequired(verificationInfo)
                 .linking(linkingInfo)
                 .build();
+    }
+
+    /**
+     * 로그인
+     *
+     * @param request 로그인 요청 정보
+     * @return LoginResponse - Access Token과 사용자 정보
+     */
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        log.info("로그인 시도: username={}", request.getUsername());
+
+        // 1. userId로 User 조회 (Fetch Join으로 Role도 함께 조회)
+        User user = userRepository.findByUserIdWithRole(request.getUsername())
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: username={}", request.getUsername());
+                    return new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+                });
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            log.warn("비밀번호 불일치: username={}", request.getUsername());
+            throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 3. Access Token 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(
+                user.getUserId(),
+                user.getRole().getRoleName()
+        );
+        log.debug("Access Token 생성 완료: userId={}", user.getUserId());
+
+        // 4. Refresh Token 생성 (rememberMe 고려)
+        boolean rememberMe = request.getRememberMe() != null && request.getRememberMe();
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId(), rememberMe);
+        log.debug("Refresh Token 생성 완료: userId={}, rememberMe={}", user.getUserId(), rememberMe);
+
+        // 5. Refresh Token을 DB에 저장
+        long expiration = rememberMe ? refreshTokenRememberMeExpiration : refreshTokenExpiration;
+        LocalDateTime refreshTokenExpiresAt = LocalDateTime.now().plusSeconds(expiration / 1000);
+        user.updateRefreshToken(refreshToken, refreshTokenExpiresAt);
+        log.debug("Refresh Token DB 저장 완료: userId={}", user.getUserId());
+
+        // 6. Response 생성
+        LoginResponse response = LoginResponse.builder()
+                .accessToken(accessToken)
+                .userId(user.getUserId())
+                .role(user.getRole().getRoleName())
+                .expiresIn(accessTokenExpiration / 1000)  // 초 단위로 변환
+                .build();
+
+        log.info("로그인 성공: userId={}, role={}", user.getUserId(), user.getRole().getRoleName());
+
+        return response;
     }
 }


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-122](https://your-jira-domain.atlassian.net/browse/BU-122)

## 📝 변경 사항 요약

근로자, 현장 관리자, 기업 관리자가 공통으로 사용할 수 있는 로그인 API를 구현했습니다.

### 주요 변경사항
- User 엔티티에 Refresh Token 저장 필드 추가
- 로그인 요청/응답 DTO 생성
- JWT 기반 인증 로그인 로직 구현
- POST /auth/login 엔드포인트 추가

## 🎯 변경 목적

사용자 인증을 위한 로그인 API를 구현하여 근로자, 현장 관리자, 기업 관리자가 시스템에 로그인할 수 있도록 합니다.

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] 로그인 API 구현: 아이디/비밀번호 기반 인증
- [x] JWT Access Token 발급 (만료: 1시간)
- [x] JWT Refresh Token 발급 및 DB 저장 (만료: 7일/30일)
- [x] RememberMe 기능 지원 (체크 시 Refresh Token 30일 유효)
- [x] 역할 기반 응답 (EMPLOYEE, MANAGER, ADMIN)

### 버그 수정 (Bug Fixes)
- 해당 없음

### 리팩토링 (Refactoring)
- 해당 없음

### 기타 변경사항 (Others)
- [x] ERD.md 업데이트: users 테이블 스키마 변경 내역 추가

## 🧪 테스트 방법

### 단위 테스트
- [ ] 단위 테스트 작성 완료
- [x] 기존 테스트 통과 확인

### 수동 테스트
1. 서버 실행: `ENCRYPTION_KEY=0123456789abcdef0123456789abcdef ./gradlew bootRun`
2. 로그인 성공 케이스 테스트
3. 로그인 실패 케이스 테스트 (잘못된 비밀번호)

### API 테스트 예시

**성공 케이스:**
```bash
curl -X POST http://localhost:8080/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{
    "username": "testuser002",
    "password": "Test123@@",
    "rememberMe": false
  }'
```

**예상 결과:**
```json
{
  "success": true,
  "message": "로그인 성공",
  "data": {
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "userId": "testuser002",
    "role": "EMPLOYEE",
    "expiresIn": 3600
  }
}
```

**실패 케이스:**
```bash
curl -X POST http://localhost:8080/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{
    "username": "testuser002",
    "password": "WrongPassword",
    "rememberMe": false
  }'
```

**예상 결과:**
```json
{
  "success": false,
  "message": "아이디 또는 비밀번호가 올바르지 않습니다.",
  "data": null
}
```

## 📸 스크린샷 (해당하는 경우)
- Swagger UI에서 POST /auth/login 엔드포인트 확인 가능

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 있음 (Hibernate auto-update 사용)

**마이그레이션 상세:**
- 변경 테이블: `users`
- 변경 내용: 
  - `refresh_token` VARCHAR(500) 컬럼 추가
  - `refresh_token_expires_at` DATETIME 컬럼 추가

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거 (환경변수 또는 설정 파일 사용)
- [x] 로그 레벨 적절히 설정 (DEBUG → INFO/WARN/ERROR)

### 테스트
- [ ] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료 (필요시)
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토 (JPA 사용)
- [x] XSS 취약점 검토 (JSON 응답만 사용)
- [x] 인증/인가 로직 검토 (BCrypt 패스워드 검증)
- [x] 민감 정보 노출 검토 (비밀번호는 응답에 포함하지 않음)
- [x] 입력 검증 로직 추가 (@Valid, @NotBlank 사용)

### 성능
- [x] N+1 쿼리 문제 검토 (findByUserIdWithRole fetch join 사용)
- [x] 불필요한 DB 쿼리 최적화
- [x] 적절한 인덱스 사용 확인
- [x] 대용량 데이터 처리 고려

### 문서
- [x] API 문서 업데이트 (Swagger 주석)
- [x] README.md 업데이트 (필요시)
- [x] 코드 주석 작성 (복잡한 로직만)
- [ ] Jira Story 상태 업데이트

### Git
- [x] Conventional Commits 규칙 준수
- [x] develop 브랜치 최신 코드 반영
- [x] 충돌 해결 완료

## 📌 리뷰어에게

- User 엔티티의 Refresh Token 필드 추가 로직 확인 부탁드립니다
- 보안 관련하여 BCrypt 패스워드 검증 로직 검토 부탁드립니다
- JWT 토큰 만료 시간 설정이 적절한지 확인 부탁드립니다 (Access: 1시간, Refresh: 7일/30일)

## 🔗 관련 PR/Issue
- 해당 없음

---

## 📚 참고 자료
- JWT 기반 인증 구현
- Spring Security BCrypt 패스워드 인코딩

[BU-122]: https://build-up-project.atlassian.net/browse/BU-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 로그인 API 엔드포인트 추가 (POST /auth/login)
  * JWT 기반 액세스 토큰 및 리프레시 토큰 발급 지원
  * 리프레시 토큰을 HttpOnly·Secure 쿠키로 설정하여 브라우저에 전달
  * "자동 로그인" 옵션으로 토큰 만료(기본/30일) 조정 가능
  * 사용자 프로필에서 리프레시 토큰 수명 관리(생성/삭제) 지원

* **Documentation**
  * 사용자 스키마에 리프레시 토큰 및 만료일 필드 추가 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->