### PR TITLE
feature/BU-127: 내 정보 조회 API 구현 (GET /auth/me)

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,7 +28,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/v1/auth")
 @RequiredArgsConstructor
 @Validated
 @Tag(name = "Auth", description = "인증/인가 API")
@@ -218,9 +219,9 @@ public class AuthController {
                     "JWT Access Token이 필요하며, SecurityContext에서 사용자 ID를 추출합니다."
     )
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
-            @Parameter(hidden = true) @org.springframework.security.core.annotation.AuthenticationPrincipal String userId
-    ) {
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo() {
+        // SecurityContext에서 인증된 사용자 ID 추출
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
         log.info("내 정보 조회 API 호출: userId={}", userId);
 
         UserInfoResponse response = authService.getMyInfo(userId);

--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -203,4 +203,30 @@ public class AuthController {
                 ApiResponse.success(loginResult.getLoginResponse(), "로그인 성공")
         );
     }
+
+    /**
+     * 내 정보 조회 API
+     *
+     * <p>인증된 사용자의 기본 정보 및 역할별 추가 정보를 조회합니다.</p>
+     * <p>JWT Access Token을 통해 사용자를 식별합니다.</p>
+     *
+     * @return UserInfoResponse - 사용자 정보 및 역할별 추가 정보
+     */
+    @Operation(
+            summary = "내 정보 조회",
+            description = "인증된 사용자의 기본 정보 및 역할별 추가 정보를 조회합니다. " +
+                    "JWT Access Token이 필요하며, SecurityContext에서 사용자 ID를 추출합니다."
+    )
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
+            @Parameter(hidden = true) @org.springframework.security.core.annotation.AuthenticationPrincipal String userId
+    ) {
+        log.info("내 정보 조회 API 호출: userId={}", userId);
+
+        UserInfoResponse response = authService.getMyInfo(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "사용자 정보 조회 성공")
+        );
+    }
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/dto/UserInfoResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/dto/UserInfoResponse.java
@@ -1,0 +1,136 @@
+package com.concrete.buildup.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 정보 조회 응답 DTO
+ *
+ * <p>인증된 사용자의 기본 정보 및 역할별 추가 정보를 반환합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 정보 조회 응답")
+public class UserInfoResponse {
+
+    @Schema(description = "사용자 ID", example = "testuser001")
+    private String userId;
+
+    @Schema(description = "사용자 역할 (EMPLOYEE, MANAGER, CORPORATION)", example = "EMPLOYEE")
+    private String role;
+
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
+
+    @Schema(description = "이메일", example = "test@example.com")
+    private String email;
+
+    @Schema(description = "역할별 추가 정보 (Employee/Manager/Corporation)")
+    private Object additionalInfo;
+
+    /**
+     * 근로자 추가 정보 DTO
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "근로자 추가 정보")
+    public static class EmployeeInfo {
+
+        @Schema(description = "근로자 ID", example = "1")
+        private Long employeeId;
+
+        @Schema(description = "근로자 이름", example = "홍길동")
+        private String empName;
+
+        @Schema(description = "주민등록번호 (마스킹)", example = "950101-*******")
+        private String residentNum;
+
+        @Schema(description = "비상 연락망", example = "010-9876-5432")
+        private String emergencyPhone;
+
+        @Schema(description = "주소", example = "서울시 강남구")
+        private String empAddress;
+
+        @Schema(description = "근로자 유형", example = "DAILY")
+        private String empType;
+
+        @Schema(description = "연결된 현장 정보")
+        private SiteInfo site;
+    }
+
+    /**
+     * 현장 관리자 추가 정보 DTO
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "현장 관리자 추가 정보")
+    public static class ManagerInfo {
+
+        @Schema(description = "관리자 ID", example = "1")
+        private Long managerId;
+
+        @Schema(description = "관리자 이름", example = "김관리")
+        private String managerName;
+
+        @Schema(description = "관리 중인 현장 정보")
+        private SiteInfo site;
+    }
+
+    /**
+     * 기업 추가 정보 DTO
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "기업 추가 정보")
+    public static class CorporationInfo {
+
+        @Schema(description = "기업 ID", example = "1")
+        private Long corporationId;
+
+        @Schema(description = "회사명", example = "주식회사 건설")
+        private String corpName;
+
+        @Schema(description = "본사 주소", example = "서울시 강남구")
+        private String corpAddress;
+
+        @Schema(description = "대표자 이름", example = "이대표")
+        private String corpCeoName;
+    }
+
+    /**
+     * 현장 정보 DTO
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "현장 정보")
+    public static class SiteInfo {
+
+        @Schema(description = "현장 ID", example = "1")
+        private Long siteId;
+
+        @Schema(description = "현장명", example = "OO아파트 신축공사")
+        private String siteName;
+
+        @Schema(description = "현장 주소", example = "서울시 강남구")
+        private String siteAddress;
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/auth/repository/ManagerRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/repository/ManagerRepository.java
@@ -1,6 +1,7 @@
 package com.concrete.buildup.domain.auth.repository;
 
 import com.concrete.buildup.domain.auth.entity.Manager;
+import com.concrete.buildup.domain.auth.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -59,4 +60,12 @@ public interface ManagerRepository extends JpaRepository<Manager, Long> {
            "LEFT JOIN FETCH u.role " +
            "WHERE u.id = :userId")
     Optional<Manager> findByUserIdWithUserAndRole(@Param("userId") Long userId);
+
+    /**
+     * User 엔티티로 관리자 조회
+     *
+     * @param user User 엔티티
+     * @return 관리자 엔티티 (Optional)
+     */
+    Optional<Manager> findByUser(User user);
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -594,17 +594,15 @@ public class AuthService {
                 // 현장 정보 조회 (secretKey로)
                 UserInfoResponse.SiteInfo siteInfo = null;
                 if (user.getSecretKey() != null && !user.getSecretKey().isBlank()) {
-                    siteRepository.findByEmployeeSecretKey(user.getSecretKey())
-                            .ifPresent(site -> {
-                                log.debug("현장 정보 조회 성공: siteId={}, siteName={}", site.getId(), site.getSiteName());
-                            });
-
                     siteInfo = siteRepository.findByEmployeeSecretKey(user.getSecretKey())
-                            .map(site -> UserInfoResponse.SiteInfo.builder()
-                                    .siteId(site.getId())
-                                    .siteName(site.getSiteName())
-                                    .siteAddress(site.getSiteAddress())
-                                    .build())
+                            .map(site -> {
+                                log.debug("현장 정보 조회 성공: siteId={}, siteName={}", site.getId(), site.getSiteName());
+                                return UserInfoResponse.SiteInfo.builder()
+                                        .siteId(site.getId())
+                                        .siteName(site.getSiteName())
+                                        .siteAddress(site.getSiteAddress())
+                                        .build();
+                            })
                             .orElse(null);
                 }
 

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -1,10 +1,12 @@
 package com.concrete.buildup.domain.auth.service;
 
 import com.concrete.buildup.domain.auth.dto.*;
+import com.concrete.buildup.domain.auth.entity.Corporation;
 import com.concrete.buildup.domain.auth.entity.Employee;
 import com.concrete.buildup.domain.auth.entity.Manager;
 import com.concrete.buildup.domain.auth.entity.Role;
 import com.concrete.buildup.domain.auth.entity.User;
+import com.concrete.buildup.domain.auth.repository.CorporationRepository;
 import com.concrete.buildup.domain.auth.repository.EmployeeRepository;
 import com.concrete.buildup.domain.auth.repository.ManagerRepository;
 import com.concrete.buildup.domain.auth.repository.RoleRepository;
@@ -47,6 +49,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final EmployeeRepository employeeRepository;
     private final ManagerRepository managerRepository;
+    private final CorporationRepository corporationRepository;
     private final RoleRepository roleRepository;
     private final SiteRepository siteRepository;
     private final PasswordEncoder passwordEncoder;
@@ -552,6 +555,135 @@ public class AuthService {
         log.info("로그인 성공: userId={}, role={}", user.getUserId(), user.getRole().getRoleName());
 
         return result;
+    }
+
+    /**
+     * 내 정보 조회
+     *
+     * <p>인증된 사용자의 기본 정보 및 역할별 추가 정보를 조회합니다.</p>
+     *
+     * @param userId 사용자 ID (로그인 ID)
+     * @return UserInfoResponse - 사용자 정보 및 역할별 추가 정보
+     */
+    public UserInfoResponse getMyInfo(String userId) {
+        log.info("내 정보 조회 시작: userId={}", userId);
+
+        // 1. userId로 User 조회 (Fetch Join으로 Role도 함께 조회)
+        User user = userRepository.findByUserIdWithRole(userId)
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: userId={}", userId);
+                    return new BusinessException(AuthErrorCode.USER_NOT_FOUND);
+                });
+
+        // 2. 역할별 추가 정보 조회
+        String roleName = user.getRole().getRoleName();
+        Object additionalInfo = null;
+        String name = null;
+
+        switch (roleName) {
+            case "EMPLOYEE":
+                // 근로자 정보 조회
+                Employee employee = employeeRepository.findByUser(user)
+                        .orElseThrow(() -> {
+                            log.error("Employee를 찾을 수 없습니다: userId={}", userId);
+                            return new BusinessException(AuthErrorCode.USER_NOT_FOUND);
+                        });
+
+                name = employee.getEmpName();
+
+                // 현장 정보 조회 (secretKey로)
+                UserInfoResponse.SiteInfo siteInfo = null;
+                if (user.getSecretKey() != null && !user.getSecretKey().isBlank()) {
+                    siteRepository.findByEmployeeSecretKey(user.getSecretKey())
+                            .ifPresent(site -> {
+                                log.debug("현장 정보 조회 성공: siteId={}, siteName={}", site.getId(), site.getSiteName());
+                            });
+
+                    siteInfo = siteRepository.findByEmployeeSecretKey(user.getSecretKey())
+                            .map(site -> UserInfoResponse.SiteInfo.builder()
+                                    .siteId(site.getId())
+                                    .siteName(site.getSiteName())
+                                    .siteAddress(site.getSiteAddress())
+                                    .build())
+                            .orElse(null);
+                }
+
+                additionalInfo = UserInfoResponse.EmployeeInfo.builder()
+                        .employeeId(employee.getId())
+                        .empName(employee.getEmpName())
+                        .residentNum(employee.getResidentNum())  // 이미 마스킹 처리됨 (Serializer)
+                        .emergencyPhone(employee.getSubPhone())
+                        .empAddress(employee.getEmpAddress())
+                        .empType(employee.getEmpType())
+                        .site(siteInfo)
+                        .build();
+                break;
+
+            case "MANAGER":
+                // 현장 관리자 정보 조회
+                Manager manager = managerRepository.findByUser(user)
+                        .orElseThrow(() -> {
+                            log.error("Manager를 찾을 수 없습니다: userId={}", userId);
+                            return new BusinessException(AuthErrorCode.USER_NOT_FOUND);
+                        });
+
+                name = manager.getManagerName();
+
+                // 현장 정보 조회 (secretKey로)
+                UserInfoResponse.SiteInfo managerSiteInfo = null;
+                if (user.getSecretKey() != null && !user.getSecretKey().isBlank()) {
+                    managerSiteInfo = siteRepository.findByManagerSecretKey(user.getSecretKey())
+                            .map(site -> UserInfoResponse.SiteInfo.builder()
+                                    .siteId(site.getId())
+                                    .siteName(site.getSiteName())
+                                    .siteAddress(site.getSiteAddress())
+                                    .build())
+                            .orElse(null);
+                }
+
+                additionalInfo = UserInfoResponse.ManagerInfo.builder()
+                        .managerId(manager.getId())
+                        .managerName(manager.getManagerName())
+                        .site(managerSiteInfo)
+                        .build();
+                break;
+
+            case "CORPORATION":
+                // 기업 정보 조회
+                Corporation corporation = corporationRepository.findByUserId(user.getId())
+                        .orElseThrow(() -> {
+                            log.error("Corporation을 찾을 수 없습니다: userId={}", userId);
+                            return new BusinessException(AuthErrorCode.USER_NOT_FOUND);
+                        });
+
+                name = corporation.getCorpName();
+
+                additionalInfo = UserInfoResponse.CorporationInfo.builder()
+                        .corporationId(corporation.getId())
+                        .corpName(corporation.getCorpName())
+                        .corpAddress(corporation.getCorpAddress())
+                        .corpCeoName(corporation.getCorpCeoName())
+                        .build();
+                break;
+
+            default:
+                log.warn("알 수 없는 역할: role={}", roleName);
+                break;
+        }
+
+        // 3. Response 생성
+        UserInfoResponse response = UserInfoResponse.builder()
+                .userId(user.getUserId())
+                .role(roleName)
+                .name(name)
+                .phone(user.getPhone())
+                .email(user.getEmail())
+                .additionalInfo(additionalInfo)
+                .build();
+
+        log.info("내 정보 조회 완료: userId={}, role={}", userId, roleName);
+
+        return response;
     }
 
     /**

--- a/src/main/java/com/concrete/buildup/global/config/SecurityConfig.java
+++ b/src/main/java/com/concrete/buildup/global/config/SecurityConfig.java
@@ -83,8 +83,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                     // 공개 엔드포인트
                     .requestMatchers(
-                        "/api/v1/auth/**",       // 인증 관련 API
-                        "/api/v1/public/**",     // 공개 API
+                        "/v1/auth/**",           // 인증 관련 API
+                        "/v1/public/**",         // 공개 API
                         "/swagger-ui/**",        // Swagger UI
                         "/v3/api-docs/**",       // Swagger API Docs
                         "/actuator/health"       // Health Check

--- a/src/test/java/com/concrete/buildup/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/auth/service/AuthServiceTest.java
@@ -1,7 +1,19 @@
 package com.concrete.buildup.domain.auth.service;
 
 import com.concrete.buildup.domain.auth.dto.UserExistsResponse;
+import com.concrete.buildup.domain.auth.dto.UserInfoResponse;
+import com.concrete.buildup.domain.auth.entity.Corporation;
+import com.concrete.buildup.domain.auth.entity.Employee;
+import com.concrete.buildup.domain.auth.entity.Manager;
+import com.concrete.buildup.domain.auth.entity.Role;
+import com.concrete.buildup.domain.auth.entity.User;
+import com.concrete.buildup.domain.auth.repository.CorporationRepository;
+import com.concrete.buildup.domain.auth.repository.EmployeeRepository;
+import com.concrete.buildup.domain.auth.repository.ManagerRepository;
 import com.concrete.buildup.domain.auth.repository.UserRepository;
+import com.concrete.buildup.domain.site.entity.Site;
+import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,7 +21,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -22,6 +38,18 @@ class AuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private ManagerRepository managerRepository;
+
+    @Mock
+    private CorporationRepository corporationRepository;
+
+    @Mock
+    private SiteRepository siteRepository;
 
     @InjectMocks
     private AuthService authService;
@@ -54,5 +82,180 @@ class AuthServiceTest {
         // then
         assertThat(response.isExists()).isFalse();
         verify(userRepository).existsByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 - 근로자(EMPLOYEE)")
+    void getMyInfo_Employee() {
+        // given
+        String userId = "employee001";
+        String secretKey = "test-secret-key";
+
+        Role employeeRole = Role.builder()
+                .roleName("EMPLOYEE")
+                .build();
+
+        User user = User.builder()
+                .userId(userId)
+                .phone("010-1234-5678")
+                .email("employee@test.com")
+                .role(employeeRole)
+                .secretKey(secretKey)
+                .build();
+
+        Employee employee = Employee.builder()
+                .user(user)
+                .empName("홍길동")
+                .residentNum("950101-*******")
+                .subPhone("010-9876-5432")
+                .empAddress("서울시 강남구")
+                .empType("DAILY")
+                .build();
+
+        Site site = Site.builder()
+                .siteName("OO아파트 신축공사")
+                .siteAddress("서울시 강남구")
+                .build();
+
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.of(user));
+        given(employeeRepository.findByUser(user)).willReturn(Optional.of(employee));
+        given(siteRepository.findByEmployeeSecretKey(secretKey)).willReturn(Optional.of(site));
+
+        // when
+        UserInfoResponse response = authService.getMyInfo(userId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(userId);
+        assertThat(response.getRole()).isEqualTo("EMPLOYEE");
+        assertThat(response.getName()).isEqualTo("홍길동");
+        assertThat(response.getPhone()).isEqualTo("010-1234-5678");
+        assertThat(response.getEmail()).isEqualTo("employee@test.com");
+
+        UserInfoResponse.EmployeeInfo empInfo = (UserInfoResponse.EmployeeInfo) response.getAdditionalInfo();
+        assertThat(empInfo).isNotNull();
+        assertThat(empInfo.getEmpName()).isEqualTo("홍길동");
+        assertThat(empInfo.getEmpAddress()).isEqualTo("서울시 강남구");
+        assertThat(empInfo.getEmpType()).isEqualTo("DAILY");
+        assertThat(empInfo.getSite()).isNotNull();
+        assertThat(empInfo.getSite().getSiteName()).isEqualTo("OO아파트 신축공사");
+
+        verify(userRepository).findByUserIdWithRole(userId);
+        verify(employeeRepository).findByUser(user);
+        verify(siteRepository).findByEmployeeSecretKey(secretKey);
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 - 현장 관리자(MANAGER)")
+    void getMyInfo_Manager() {
+        // given
+        String userId = "manager001";
+        String secretKey = "test-manager-key";
+
+        Role managerRole = Role.builder()
+                .roleName("MANAGER")
+                .build();
+
+        User user = User.builder()
+                .userId(userId)
+                .phone("010-1111-2222")
+                .email("manager@test.com")
+                .role(managerRole)
+                .secretKey(secretKey)
+                .build();
+
+        Manager manager = Manager.builder()
+                .user(user)
+                .managerName("김관리")
+                .build();
+
+        Site site = Site.builder()
+                .siteName("OO현장")
+                .siteAddress("서울시 강남구")
+                .build();
+
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.of(user));
+        given(managerRepository.findByUser(user)).willReturn(Optional.of(manager));
+        given(siteRepository.findByManagerSecretKey(secretKey)).willReturn(Optional.of(site));
+
+        // when
+        UserInfoResponse response = authService.getMyInfo(userId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(userId);
+        assertThat(response.getRole()).isEqualTo("MANAGER");
+        assertThat(response.getName()).isEqualTo("김관리");
+
+        UserInfoResponse.ManagerInfo mgrInfo = (UserInfoResponse.ManagerInfo) response.getAdditionalInfo();
+        assertThat(mgrInfo).isNotNull();
+        assertThat(mgrInfo.getManagerName()).isEqualTo("김관리");
+        assertThat(mgrInfo.getSite()).isNotNull();
+        assertThat(mgrInfo.getSite().getSiteName()).isEqualTo("OO현장");
+
+        verify(userRepository).findByUserIdWithRole(userId);
+        verify(managerRepository).findByUser(user);
+        verify(siteRepository).findByManagerSecretKey(secretKey);
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 - 기업(CORPORATION)")
+    void getMyInfo_Corporation() {
+        // given
+        String userId = "corp001";
+
+        Role corpRole = Role.builder()
+                .roleName("CORPORATION")
+                .build();
+
+        // User 엔티티 생성 (id는 BaseEntity에서 관리되므로 직접 설정하지 않음)
+        User user = User.builder()
+                .userId(userId)
+                .phone("02-1234-5678")
+                .email("corp@test.com")
+                .role(corpRole)
+                .build();
+
+        Corporation corporation = Corporation.builder()
+                .user(user)
+                .corpName("주식회사 건설")
+                .corpAddress("서울시 강남구")
+                .corpCeoName("이대표")
+                .build();
+
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.of(user));
+        given(corporationRepository.findByUserId(any())).willReturn(Optional.of(corporation));
+
+        // when
+        UserInfoResponse response = authService.getMyInfo(userId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(userId);
+        assertThat(response.getRole()).isEqualTo("CORPORATION");
+        assertThat(response.getName()).isEqualTo("주식회사 건설");
+
+        UserInfoResponse.CorporationInfo corpInfo = (UserInfoResponse.CorporationInfo) response.getAdditionalInfo();
+        assertThat(corpInfo).isNotNull();
+        assertThat(corpInfo.getCorpName()).isEqualTo("주식회사 건설");
+        assertThat(corpInfo.getCorpAddress()).isEqualTo("서울시 강남구");
+        assertThat(corpInfo.getCorpCeoName()).isEqualTo("이대표");
+
+        verify(userRepository).findByUserIdWithRole(userId);
+        verify(corporationRepository).findByUserId(any());
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 - 사용자를 찾을 수 없음")
+    void getMyInfo_UserNotFound() {
+        // given
+        String userId = "nonexistent";
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.getMyInfo(userId))
+                .isInstanceOf(BusinessException.class);
+
+        verify(userRepository).findByUserIdWithRole(userId);
     }
 }


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: BU-127

## 📝 변경 사항 요약

인증된 사용자의 정보를 조회하는 GET /auth/me API를 구현했습니다. JWT Access Token을 통해 사용자를 식별하고, 역할(EMPLOYEE, MANAGER, CORPORATION)에 따라 추가 정보를 함께 반환합니다.

### 주요 변경사항
- UserInfoResponse DTO 및 역할별 중첩 클래스 생성
- AuthService.getMyInfo() 메서드 구현 (역할 기반 정보 조회)
- AuthController GET /auth/me 엔드포인트 추가
- SecurityContext에서 userId 추출 로직 개선
- SecurityConfig 경로 매핑 수정 (context-path 중복 제거)

## 🎯 변경 목적

사용자가 로그인 후 자신의 정보를 조회할 수 있는 기능을 제공하기 위함입니다. 역할에 따라 근로자, 현장 관리자, 기업의 추가 정보를 함께 반환하여 클라이언트에서 사용자 프로필을 구성할 수 있도록 합니다.

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] UserInfoResponse DTO 생성 (기본 정보 + 역할별 추가 정보)
- [x] AuthService.getMyInfo() 메서드 구현
- [x] AuthController GET /auth/me 엔드포인트 추가
- [x] ManagerRepository.findByUser() 메서드 추가

### 버그 수정 (Bug Fixes)
- [x] SecurityConfig 경로 매핑 수정 (context-path와 Controller 매핑 중복 문제 해결)
- [x] AuthController SecurityContext userId 추출 로직 개선

### 리팩토링 (Refactoring)
- [x] AuthController @RequestMapping 경로 수정 (/api/v1/auth → /v1/auth)
- [x] SecurityConfig requestMatchers 경로 수정 (/api/v1/auth/** → /v1/auth/**)

## 🧪 테스트 방법

### 단위 테스트
- [x] 단위 테스트 작성 완료
- [x] 기존 테스트 통과 확인
- 테스트 케이스:
  - getMyInfo_Employee(): 근로자 정보 조회 테스트
  - getMyInfo_Manager(): 현장 관리자 정보 조회 테스트
  - getMyInfo_Corporation(): 기업 정보 조회 테스트
  - getMyInfo_UserNotFound(): 사용자 미존재 예외 테스트

### 수동 테스트
1. 회원가입 API로 테스트 사용자 생성
2. 로그인 API로 JWT Access Token 발급
3. GET /auth/me API 호출하여 사용자 정보 조회 확인

### API 테스트 예시
```bash
# 1. 로그인
curl -X POST http://localhost:8080/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username":"testuser001","password":"Test1234@"}'

# 2. 내 정보 조회
curl -X GET http://localhost:8080/api/v1/auth/me \
  -H "Authorization: Bearer {access_token}" \
  -H "Content-Type: application/json"
```

**예상 결과:**
```json
{
  "success": true,
  "message": "사용자 정보 조회 성공",
  "data": {
    "userId": "testuser001",
    "role": "EMPLOYEE",
    "name": "테스트사용자",
    "phone": "01012345678",
    "email": null,
    "additionalInfo": {
      "employeeId": 6,
      "empName": "테스트사용자",
      "residentNum": "암호화된값",
      "emergencyPhone": "01098765432",
      "empAddress": "서울시 강남구",
      "empType": null,
      "site": null
    }
  }
}
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거 (환경변수 또는 설정 파일 사용)
- [x] 로그 레벨 적절히 설정 (DEBUG → INFO/WARN/ERROR)

### 테스트
- [x] 단위 테스트 작성 완료
- [x] 통합 테스트 작성 완료 (필요시)
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토
- [x] XSS 취약점 검토
- [x] 인증/인가 로직 검토
- [x] 민감 정보 노출 검토 (비밀번호, API 키 등)
- [x] 입력 검증 로직 추가

### 성능
- [x] N+1 쿼리 문제 검토
- [x] 불필요한 DB 쿼리 최적화
- [x] 적절한 인덱스 사용 확인
- [x] 대용량 데이터 처리 고려

### 문서
- [x] API 문서 업데이트 (Swagger 주석)
- [x] README.md 업데이트 (필요시)
- [x] 코드 주석 작성 (복잡한 로직만)
- [x] Jira Story 상태 업데이트

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (BU-127)
- [ ] develop 브랜치 최신 코드 반영 (rebase)
- [x] 충돌 해결 완료

## 📌 리뷰어에게

- SecurityContext에서 userId를 추출하는 로직이 SecurityContextHolder.getContext().getAuthentication().getName()을 사용하도록 변경되었습니다.
- context-path 설정으로 인한 경로 중복 문제를 해결했습니다 (application.yml의 context-path가 /api로 설정되어 있어 Controller 매핑에서 /api 제거)
- 역할별 추가 정보 조회 시 Optional 처리를 통해 null-safe하게 구현했습니다.

## 🔗 관련 PR/Issue
- Related Issue: BU-127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증된 사용자의 프로필 정보를 조회하는 `/me` 엔드포인트 추가
  * 역할별(직원, 매니저, 회사) 상세 사용자 정보 반환 기능 구현

* **테스트**
  * 사용자 정보 조회 기능에 대한 포괄적인 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->