### PR TITLE
feature/BU-142 토큰 갱신 API 구현 (Refresh Token Rotation)

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -230,4 +230,55 @@ public class AuthController {
                 ApiResponse.success(response, "사용자 정보 조회 성공")
         );
     }
+
+    /**
+     * 토큰 재발급 API
+     *
+     * <p>Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 재발급합니다.</p>
+     * <p>Refresh Token은 HttpOnly 쿠키에서 자동으로 읽어옵니다.</p>
+     * <p>새로운 Refresh Token은 HttpOnly 쿠키로 전달됩니다 (Refresh Token Rotation).</p>
+     *
+     * @param request HTTP 요청 (쿠키에서 Refresh Token 읽기)
+     * @param response HTTP 응답 (새로운 Refresh Token 쿠키 설정)
+     * @return TokenRefreshResponse - 새로운 Access Token
+     */
+    @Operation(
+            summary = "토큰 재발급",
+            description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 재발급합니다. " +
+                    "Refresh Token은 HttpOnly 쿠키에서 자동으로 읽어오며, " +
+                    "새로운 Refresh Token은 HttpOnly 쿠키로 전달됩니다 (Refresh Token Rotation)."
+    )
+    @PostMapping("/token/refresh")
+    public ResponseEntity<ApiResponse<LoginResponse>> refreshToken(
+            jakarta.servlet.http.HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        log.info("토큰 재발급 API 호출");
+
+        // 쿠키에서 Refresh Token 읽기
+        String refreshToken = com.concrete.buildup.global.util.CookieUtil.getCookieValue(request, "refreshToken")
+                .orElseThrow(() -> {
+                    log.warn("Refresh Token 쿠키를 찾을 수 없음");
+                    return new com.concrete.buildup.global.exception.BusinessException(
+                            com.concrete.buildup.global.exception.errorcode.AuthErrorCode.REFRESH_TOKEN_NOT_FOUND
+                    );
+                });
+
+        // 토큰 재발급 처리
+        LoginResult loginResult = authService.refreshToken(refreshToken);
+
+        // 새로운 Refresh Token을 HttpOnly 쿠키로 설정
+        Cookie refreshTokenCookie = new Cookie("refreshToken", loginResult.getRefreshToken());
+        refreshTokenCookie.setHttpOnly(true);  // XSS 공격 방어
+        refreshTokenCookie.setSecure(true);     // HTTPS에서만 전송
+        refreshTokenCookie.setPath("/");        // 모든 경로에서 접근 가능
+        refreshTokenCookie.setMaxAge(loginResult.getRefreshTokenMaxAge().intValue());  // 만료 시간 설정
+        response.addCookie(refreshTokenCookie);
+
+        log.debug("새로운 Refresh Token 쿠키 설정 완료: maxAge={}초", loginResult.getRefreshTokenMaxAge());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(loginResult.getLoginResponse(), "토큰 재발급 성공")
+        );
+    }
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -190,13 +190,15 @@ public class AuthController {
         // 로그인 처리
         LoginResult loginResult = authService.login(request);
 
-        // Refresh Token을 HttpOnly 쿠키로 설정
-        Cookie refreshTokenCookie = new Cookie("refreshToken", loginResult.getRefreshToken());
-        refreshTokenCookie.setHttpOnly(true);  // XSS 공격 방어
-        refreshTokenCookie.setSecure(true);     // HTTPS에서만 전송
-        refreshTokenCookie.setPath("/");        // 모든 경로에서 접근 가능
-        refreshTokenCookie.setMaxAge(loginResult.getRefreshTokenMaxAge().intValue());  // 만료 시간 설정
-        response.addCookie(refreshTokenCookie);
+        // Refresh Token을 HttpOnly 쿠키로 설정 (SameSite=Strict 포함)
+        org.springframework.http.ResponseCookie refreshTokenCookie = org.springframework.http.ResponseCookie.from("refreshToken", loginResult.getRefreshToken())
+                .httpOnly(true)          // XSS 공격 방어
+                .secure(true)            // HTTPS에서만 전송
+                .path("/")               // 모든 경로에서 접근 가능
+                .maxAge(loginResult.getRefreshTokenMaxAge())  // 만료 시간 설정
+                .sameSite("Strict")      // CSRF 방어: 동일 사이트에서만 전송
+                .build();
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
         log.debug("Refresh Token 쿠키 설정 완료: maxAge={}초", loginResult.getRefreshTokenMaxAge());
 
@@ -267,13 +269,15 @@ public class AuthController {
         // 토큰 재발급 처리
         LoginResult loginResult = authService.refreshToken(refreshToken);
 
-        // 새로운 Refresh Token을 HttpOnly 쿠키로 설정
-        Cookie refreshTokenCookie = new Cookie("refreshToken", loginResult.getRefreshToken());
-        refreshTokenCookie.setHttpOnly(true);  // XSS 공격 방어
-        refreshTokenCookie.setSecure(true);     // HTTPS에서만 전송
-        refreshTokenCookie.setPath("/");        // 모든 경로에서 접근 가능
-        refreshTokenCookie.setMaxAge(loginResult.getRefreshTokenMaxAge().intValue());  // 만료 시간 설정
-        response.addCookie(refreshTokenCookie);
+        // 새로운 Refresh Token을 HttpOnly 쿠키로 설정 (SameSite=Strict 포함)
+        org.springframework.http.ResponseCookie newRefreshTokenCookie = org.springframework.http.ResponseCookie.from("refreshToken", loginResult.getRefreshToken())
+                .httpOnly(true)          // XSS 공격 방어
+                .secure(true)            // HTTPS에서만 전송
+                .path("/")               // 모든 경로에서 접근 가능
+                .maxAge(loginResult.getRefreshTokenMaxAge())  // 만료 시간 설정
+                .sameSite("Strict")      // CSRF 방어: 동일 사이트에서만 전송
+                .build();
+        response.addHeader("Set-Cookie", newRefreshTokenCookie.toString());
 
         log.debug("새로운 Refresh Token 쿠키 설정 완료: maxAge={}초", loginResult.getRefreshTokenMaxAge());
 

--- a/src/main/java/com/concrete/buildup/domain/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,30 @@
+package com.concrete.buildup.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 토큰 재발급 응답 DTO
+ *
+ * <p>Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 재발급한 결과를 반환합니다.</p>
+ * <p>새로운 Refresh Token은 HttpOnly 쿠키로 전달됩니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "토큰 재발급 응답")
+public class TokenRefreshResponse {
+
+    @Schema(description = "새로운 Access Token (JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "Access Token 만료 시간 (초)", example = "3600")
+    private Long expiresIn;
+}

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -745,15 +745,28 @@ public class AuthService {
         );
         log.debug("새로운 Access Token 생성 완료: userId={}", user.getUserId());
 
-        // 8. Refresh Token Rotation: 새로운 Refresh Token 생성
-        String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId(), false);
+        // 8. 기존 Refresh Token의 만료 시간으로 rememberMe 여부 판단
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = user.getRefreshTokenExpiresAt();
+        long remainingTime = java.time.Duration.between(now, expiresAt).toMillis();
+
+        // 남은 시간이 일반 만료시간(7일)보다 길면 rememberMe=true로 간주
+        boolean isRememberMe = remainingTime > refreshTokenExpiration;
+        long expiration = isRememberMe ? refreshTokenRememberMeExpiration : refreshTokenExpiration;
+
+        log.debug("기존 토큰 rememberMe 판단: isRememberMe={}, remainingTime={}ms, threshold={}ms",
+                isRememberMe, remainingTime, refreshTokenExpiration);
+
+        // 9. Refresh Token Rotation: 새로운 Refresh Token 생성 (기존 rememberMe 유지)
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId(), isRememberMe);
         String hashedNewRefreshToken = hashToken(newRefreshToken);
         LocalDateTime newRefreshTokenExpiresAt = LocalDateTime.now()
-                .plusSeconds(refreshTokenExpiration / 1000);
+                .plusSeconds(expiration / 1000);
         user.updateRefreshToken(hashedNewRefreshToken, newRefreshTokenExpiresAt);
-        log.debug("새로운 Refresh Token 생성 및 DB 저장 완료: userId={}", user.getUserId());
+        log.debug("새로운 Refresh Token 생성 및 DB 저장 완료: userId={}, rememberMe={}",
+                user.getUserId(), isRememberMe);
 
-        // 9. Response 생성
+        // 10. Response 생성
         LoginResponse loginResponse = LoginResponse.builder()
                 .accessToken(newAccessToken)
                 .userId(user.getUserId())
@@ -761,14 +774,14 @@ public class AuthService {
                 .expiresIn(accessTokenExpiration / 1000)  // 초 단위로 변환
                 .build();
 
-        // 10. LoginResult 생성 (새로운 refreshToken 포함, 평문)
+        // 11. LoginResult 생성 (새로운 refreshToken 포함, 평문)
         LoginResult result = LoginResult.builder()
                 .loginResponse(loginResponse)
                 .refreshToken(newRefreshToken)  // 평문 토큰 (쿠키로 전달용)
-                .refreshTokenMaxAge(refreshTokenExpiration / 1000)  // 초 단위로 변환
+                .refreshTokenMaxAge(expiration / 1000)  // 초 단위로 변환 (rememberMe 반영)
                 .build();
 
-        log.info("토큰 재발급 성공: userId={}", user.getUserId());
+        log.info("토큰 재발급 성공: userId={}, rememberMe={}", user.getUserId(), isRememberMe);
 
         return result;
     }

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -685,6 +685,95 @@ public class AuthService {
     }
 
     /**
+     * 토큰 재발급
+     *
+     * <p>Refresh Token을 검증하고 새로운 Access Token과 Refresh Token을 발급합니다.</p>
+     * <p>Refresh Token Rotation 적용: 새로운 Refresh Token 발급 시 기존 토큰 무효화</p>
+     *
+     * @param refreshToken Refresh Token (평문)
+     * @return TokenRefreshResponse - 새로운 Access Token과 만료 시간
+     * @throws BusinessException INVALID_REFRESH_TOKEN: 유효하지 않은 토큰
+     * @throws BusinessException REFRESH_TOKEN_MISMATCH: DB와 일치하지 않는 토큰
+     * @throws BusinessException USER_NOT_FOUND: 사용자를 찾을 수 없음
+     */
+    @Transactional
+    public LoginResult refreshToken(String refreshToken) {
+        log.info("토큰 재발급 요청");
+
+        // 1. Refresh Token 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            log.warn("유효하지 않은 Refresh Token");
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 2. 토큰 타입 확인 (refresh 타입인지 확인)
+        String tokenType = jwtTokenProvider.getTokenType(refreshToken);
+        if (!"refresh".equals(tokenType)) {
+            log.warn("Refresh Token이 아닌 토큰 타입: type={}", tokenType);
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 3. userId 추출
+        String userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        log.debug("토큰에서 userId 추출: userId={}", userId);
+
+        // 4. DB에서 User 조회
+        User user = userRepository.findByUserIdWithRole(userId)
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: userId={}", userId);
+                    return new BusinessException(AuthErrorCode.USER_NOT_FOUND);
+                });
+
+        // 5. DB에 저장된 Refresh Token과 비교 (해시 비교)
+        String hashedRefreshToken = hashToken(refreshToken);
+        if (!hashedRefreshToken.equals(user.getRefreshToken())) {
+            log.warn("Refresh Token 불일치: userId={}", userId);
+            throw new BusinessException(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        // 6. Refresh Token 만료 시간 확인
+        if (user.getRefreshTokenExpiresAt() == null ||
+            LocalDateTime.now().isAfter(user.getRefreshTokenExpiresAt())) {
+            log.warn("만료된 Refresh Token: userId={}", userId);
+            throw new BusinessException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+
+        // 7. 새로운 Access Token 생성
+        String newAccessToken = jwtTokenProvider.generateAccessToken(
+                user.getUserId(),
+                user.getRole().getRoleName()
+        );
+        log.debug("새로운 Access Token 생성 완료: userId={}", user.getUserId());
+
+        // 8. Refresh Token Rotation: 새로운 Refresh Token 생성
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId(), false);
+        String hashedNewRefreshToken = hashToken(newRefreshToken);
+        LocalDateTime newRefreshTokenExpiresAt = LocalDateTime.now()
+                .plusSeconds(refreshTokenExpiration / 1000);
+        user.updateRefreshToken(hashedNewRefreshToken, newRefreshTokenExpiresAt);
+        log.debug("새로운 Refresh Token 생성 및 DB 저장 완료: userId={}", user.getUserId());
+
+        // 9. Response 생성
+        LoginResponse loginResponse = LoginResponse.builder()
+                .accessToken(newAccessToken)
+                .userId(user.getUserId())
+                .role(user.getRole().getRoleName())
+                .expiresIn(accessTokenExpiration / 1000)  // 초 단위로 변환
+                .build();
+
+        // 10. LoginResult 생성 (새로운 refreshToken 포함, 평문)
+        LoginResult result = LoginResult.builder()
+                .loginResponse(loginResponse)
+                .refreshToken(newRefreshToken)  // 평문 토큰 (쿠키로 전달용)
+                .refreshTokenMaxAge(refreshTokenExpiration / 1000)  // 초 단위로 변환
+                .build();
+
+        log.info("토큰 재발급 성공: userId={}", user.getUserId());
+
+        return result;
+    }
+
+    /**
      * 토큰을 SHA-256으로 해시 처리
      *
      * <p>Refresh Token을 DB에 안전하게 저장하기 위해 SHA-256으로 해시합니다.</p>

--- a/src/main/java/com/concrete/buildup/global/config/SecurityConfig.java
+++ b/src/main/java/com/concrete/buildup/global/config/SecurityConfig.java
@@ -14,6 +14,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -23,7 +25,7 @@ import java.util.List;
 /**
  * Spring Security 설정
  * - CORS 설정
- * - CSRF 설정 (REST API용 비활성화)
+ * - CSRF 설정 (쿠키 기반 토큰: XSRF-TOKEN 쿠키 + X-XSRF-TOKEN 헤더)
  * - 인증/인가 설정
  * - 세션 관리
  * - JWT 인증 필터
@@ -50,10 +52,17 @@ public class SecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-            // CSRF 비활성화 (REST API 사용 시)
-            .csrf(csrf -> csrf.disable())
+        // CSRF 설정: dev/test/local 프로파일에서는 비활성화, prod에서는 쿠키 기반 토큰 사용
+        if (isDevelopmentMode()) {
+            http.csrf(csrf -> csrf.disable());
+        } else {
+            http.csrf(csrf -> csrf
+                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+            );
+        }
 
+        http
             // CORS 설정 활성화
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 

--- a/src/main/java/com/concrete/buildup/global/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/concrete/buildup/global/exception/errorcode/AuthErrorCode.java
@@ -30,6 +30,10 @@ public enum AuthErrorCode implements BaseErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 1006, "만료된 토큰입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1007, "유효하지 않은 토큰입니다."),
     REGISTRATION_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 1010, "등록 토큰이 만료되었습니다. 1단계부터 다시 진행해주세요."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 1011, "유효하지 않은 Refresh Token입니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, 1012, "Refresh Token이 일치하지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 1013, "만료된 Refresh Token입니다. 다시 로그인해주세요."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1014, "Refresh Token을 찾을 수 없습니다."),
 
     // 403 Forbidden
     ACCESS_DENIED(HttpStatus.FORBIDDEN, 1008, "접근 권한이 없습니다.");

--- a/src/main/java/com/concrete/buildup/global/util/CookieUtil.java
+++ b/src/main/java/com/concrete/buildup/global/util/CookieUtil.java
@@ -1,0 +1,69 @@
+package com.concrete.buildup.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * 쿠키 유틸리티
+ *
+ * HTTP 쿠키 생성, 조회, 삭제 기능을 제공합니다.
+ */
+public class CookieUtil {
+
+    /**
+     * 쿠키 생성
+     *
+     * @param name 쿠키 이름
+     * @param value 쿠키 값
+     * @param maxAge 만료 시간 (초)
+     * @param httpOnly HttpOnly 플래그
+     * @param secure Secure 플래그
+     * @return Cookie 객체
+     */
+    public static Cookie createCookie(String name, String value, int maxAge, boolean httpOnly, boolean secure) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(httpOnly);
+        cookie.setSecure(secure);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        return cookie;
+    }
+
+    /**
+     * 쿠키 값 조회
+     *
+     * @param request HTTP 요청
+     * @param name 쿠키 이름
+     * @return 쿠키 값 (Optional)
+     */
+    public static Optional<String> getCookieValue(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> name.equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue);
+    }
+
+    /**
+     * 쿠키 삭제
+     *
+     * @param response HTTP 응답
+     * @param name 쿠키 이름
+     */
+    public static void deleteCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(cookie);
+    }
+}

--- a/src/test/java/com/concrete/buildup/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/auth/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.concrete.buildup.domain.auth.service;
 
+import com.concrete.buildup.domain.auth.dto.LoginResult;
 import com.concrete.buildup.domain.auth.dto.UserExistsResponse;
 import com.concrete.buildup.domain.auth.dto.UserInfoResponse;
 import com.concrete.buildup.domain.auth.entity.Corporation;
@@ -14,18 +15,27 @@ import com.concrete.buildup.domain.auth.repository.UserRepository;
 import com.concrete.buildup.domain.site.entity.Site;
 import com.concrete.buildup.domain.site.repository.SiteRepository;
 import com.concrete.buildup.global.exception.BusinessException;
+import com.concrete.buildup.global.exception.errorcode.AuthErrorCode;
+import com.concrete.buildup.global.util.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -51,8 +61,31 @@ class AuthServiceTest {
     @Mock
     private SiteRepository siteRepository;
 
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
     @InjectMocks
     private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        // AuthService의 private 필드 값 설정
+        ReflectionTestUtils.setField(authService, "accessTokenExpiration", 3600000L);  // 1시간
+        ReflectionTestUtils.setField(authService, "refreshTokenExpiration", 604800000L);  // 7일
+    }
+
+    /**
+     * 토큰을 SHA-256으로 해시 처리 (테스트용 헬퍼 메서드)
+     */
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (Exception e) {
+            throw new RuntimeException("Hash error", e);
+        }
+    }
 
     @Test
     @DisplayName("아이디 중복 확인 - 존재하는 아이디")
@@ -256,6 +289,179 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.getMyInfo(userId))
                 .isInstanceOf(BusinessException.class);
 
+        verify(userRepository).findByUserIdWithRole(userId);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 - 정상 갱신 성공")
+    void refreshToken_Success() {
+        // given
+        String refreshToken = "valid-refresh-token";
+        String userId = "testuser";
+        String hashedRefreshToken = hashToken(refreshToken);  // 실제 해시 값 사용
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(7);
+
+        Role role = Role.builder()
+                .roleName("EMPLOYEE")
+                .build();
+
+        User user = User.builder()
+                .userId(userId)
+                .role(role)
+                .refreshToken(hashedRefreshToken)
+                .refreshTokenExpiresAt(expiresAt)
+                .build();
+
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getTokenType(refreshToken)).willReturn("refresh");
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.of(user));
+        given(jwtTokenProvider.generateAccessToken(userId, "EMPLOYEE")).willReturn("new-access-token");
+        given(jwtTokenProvider.generateRefreshToken(userId, false)).willReturn("new-refresh-token");
+
+        // when
+        LoginResult result = authService.refreshToken(refreshToken);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getLoginResponse()).isNotNull();
+        assertThat(result.getLoginResponse().getAccessToken()).isEqualTo("new-access-token");
+        assertThat(result.getLoginResponse().getUserId()).isEqualTo(userId);
+        assertThat(result.getLoginResponse().getRole()).isEqualTo("EMPLOYEE");
+        assertThat(result.getRefreshToken()).isEqualTo("new-refresh-token");
+
+        verify(jwtTokenProvider).validateToken(refreshToken);
+        verify(jwtTokenProvider).getTokenType(refreshToken);
+        verify(jwtTokenProvider).getUserIdFromToken(refreshToken);
+        verify(userRepository).findByUserIdWithRole(userId);
+        verify(jwtTokenProvider).generateAccessToken(userId, "EMPLOYEE");
+        verify(jwtTokenProvider).generateRefreshToken(userId, false);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 - 유효하지 않은 토큰")
+    void refreshToken_InvalidToken() {
+        // given
+        String invalidToken = "invalid-token";
+        given(jwtTokenProvider.validateToken(invalidToken)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(invalidToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.INVALID_REFRESH_TOKEN);
+
+        verify(jwtTokenProvider).validateToken(invalidToken);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 - Refresh Token이 아닌 Access Token 사용")
+    void refreshToken_NotRefreshToken() {
+        // given
+        String accessToken = "access-token";
+        given(jwtTokenProvider.validateToken(accessToken)).willReturn(true);
+        given(jwtTokenProvider.getTokenType(accessToken)).willReturn("access");
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(accessToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.INVALID_REFRESH_TOKEN);
+
+        verify(jwtTokenProvider).validateToken(accessToken);
+        verify(jwtTokenProvider).getTokenType(accessToken);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 - 사용자를 찾을 수 없음")
+    void refreshToken_UserNotFound() {
+        // given
+        String refreshToken = "valid-refresh-token";
+        String userId = "nonexistent";
+
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getTokenType(refreshToken)).willReturn("refresh");
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(refreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.USER_NOT_FOUND);
+
+        verify(jwtTokenProvider).validateToken(refreshToken);
+        verify(jwtTokenProvider).getTokenType(refreshToken);
+        verify(jwtTokenProvider).getUserIdFromToken(refreshToken);
+        verify(userRepository).findByUserIdWithRole(userId);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 - Refresh Token 불일치")
+    void refreshToken_TokenMismatch() {
+        // given
+        String refreshToken = "valid-refresh-token";
+        String userId = "testuser";
+        String differentHashedToken = "different-hashed-token";
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(7);
+
+        Role role = Role.builder()
+                .roleName("EMPLOYEE")
+                .build();
+
+        User user = User.builder()
+                .userId(userId)
+                .role(role)
+                .refreshToken(differentHashedToken)
+                .refreshTokenExpiresAt(expiresAt)
+                .build();
+
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getTokenType(refreshToken)).willReturn("refresh");
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(refreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+
+        verify(jwtTokenProvider).validateToken(refreshToken);
+        verify(jwtTokenProvider).getTokenType(refreshToken);
+        verify(jwtTokenProvider).getUserIdFromToken(refreshToken);
+        verify(userRepository).findByUserIdWithRole(userId);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 - 만료된 Refresh Token")
+    void refreshToken_ExpiredToken() {
+        // given
+        String refreshToken = "valid-refresh-token";
+        String userId = "testuser";
+        String hashedRefreshToken = hashToken(refreshToken);  // 실제 해시 값 사용
+        LocalDateTime expiredTime = LocalDateTime.now().minusDays(1);  // 이미 만료됨
+
+        Role role = Role.builder()
+                .roleName("EMPLOYEE")
+                .build();
+
+        User user = User.builder()
+                .userId(userId)
+                .role(role)
+                .refreshToken(hashedRefreshToken)
+                .refreshTokenExpiresAt(expiredTime)
+                .build();
+
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getTokenType(refreshToken)).willReturn("refresh");
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findByUserIdWithRole(userId)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(refreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+
+        verify(jwtTokenProvider).validateToken(refreshToken);
+        verify(jwtTokenProvider).getTokenType(refreshToken);
+        verify(jwtTokenProvider).getUserIdFromToken(refreshToken);
         verify(userRepository).findByUserIdWithRole(userId);
     }
 }

--- a/src/test/java/com/concrete/buildup/global/util/CookieUtilTest.java
+++ b/src/test/java/com/concrete/buildup/global/util/CookieUtilTest.java
@@ -1,0 +1,172 @@
+package com.concrete.buildup.global.util;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CookieUtil 단위 테스트
+ */
+@DisplayName("CookieUtil 테스트")
+class CookieUtilTest {
+
+    @Test
+    @DisplayName("쿠키 생성 - 기본 옵션")
+    void createCookie_Default() {
+        // given
+        String name = "testCookie";
+        String value = "testValue";
+        int maxAge = 3600;
+
+        // when
+        Cookie cookie = CookieUtil.createCookie(name, value, maxAge, true, true);
+
+        // then
+        assertThat(cookie).isNotNull();
+        assertThat(cookie.getName()).isEqualTo(name);
+        assertThat(cookie.getValue()).isEqualTo(value);
+        assertThat(cookie.getMaxAge()).isEqualTo(maxAge);
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getSecure()).isTrue();
+        assertThat(cookie.getPath()).isEqualTo("/");
+    }
+
+    @Test
+    @DisplayName("쿠키 생성 - HttpOnly 및 Secure 플래그 false")
+    void createCookie_WithoutSecurityFlags() {
+        // given
+        String name = "insecureCookie";
+        String value = "insecureValue";
+        int maxAge = 1800;
+
+        // when
+        Cookie cookie = CookieUtil.createCookie(name, value, maxAge, false, false);
+
+        // then
+        assertThat(cookie).isNotNull();
+        assertThat(cookie.getName()).isEqualTo(name);
+        assertThat(cookie.getValue()).isEqualTo(value);
+        assertThat(cookie.isHttpOnly()).isFalse();
+        assertThat(cookie.getSecure()).isFalse();
+    }
+
+    @Test
+    @DisplayName("쿠키 값 조회 - 쿠키가 존재하는 경우")
+    void getCookieValue_CookieExists() {
+        // given
+        String cookieName = "refreshToken";
+        String cookieValue = "test-refresh-token-value";
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie(cookieName, cookieValue));
+
+        // when
+        Optional<String> result = CookieUtil.getCookieValue(request, cookieName);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(cookieValue);
+    }
+
+    @Test
+    @DisplayName("쿠키 값 조회 - 쿠키가 존재하지 않는 경우")
+    void getCookieValue_CookieNotExists() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("otherCookie", "otherValue"));
+
+        // when
+        Optional<String> result = CookieUtil.getCookieValue(request, "refreshToken");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("쿠키 값 조회 - 요청에 쿠키가 없는 경우")
+    void getCookieValue_NoCookies() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        // 쿠키를 설정하지 않음
+
+        // when
+        Optional<String> result = CookieUtil.getCookieValue(request, "refreshToken");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("쿠키 값 조회 - 여러 쿠키 중에서 특정 쿠키 찾기")
+    void getCookieValue_MultipleCookies() {
+        // given
+        String targetCookieName = "refreshToken";
+        String targetCookieValue = "correct-token";
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(
+                new Cookie("sessionId", "session123"),
+                new Cookie(targetCookieName, targetCookieValue),
+                new Cookie("userId", "user456")
+        );
+
+        // when
+        Optional<String> result = CookieUtil.getCookieValue(request, targetCookieName);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(targetCookieValue);
+    }
+
+    @Test
+    @DisplayName("쿠키 삭제 - 정상 삭제")
+    void deleteCookie_Success() {
+        // given
+        String cookieName = "refreshToken";
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        CookieUtil.deleteCookie(response, cookieName);
+
+        // then
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotNull();
+        assertThat(cookies).hasSize(1);
+
+        Cookie deletedCookie = cookies[0];
+        assertThat(deletedCookie.getName()).isEqualTo(cookieName);
+        assertThat(deletedCookie.getValue()).isNull();
+        assertThat(deletedCookie.getMaxAge()).isEqualTo(0);  // 즉시 만료
+        assertThat(deletedCookie.isHttpOnly()).isTrue();
+        assertThat(deletedCookie.getSecure()).isTrue();
+        assertThat(deletedCookie.getPath()).isEqualTo("/");
+    }
+
+    @Test
+    @DisplayName("쿠키 삭제 - 여러 쿠키 삭제")
+    void deleteCookie_MultipleCookies() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        CookieUtil.deleteCookie(response, "cookie1");
+        CookieUtil.deleteCookie(response, "cookie2");
+
+        // then
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotNull();
+        assertThat(cookies).hasSize(2);
+
+        assertThat(cookies[0].getName()).isEqualTo("cookie1");
+        assertThat(cookies[0].getMaxAge()).isEqualTo(0);
+
+        assertThat(cookies[1].getName()).isEqualTo("cookie2");
+        assertThat(cookies[1].getMaxAge()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-142](https://concrete-tech.atlassian.net/browse/BU-142)

## 📝 변경 사항 요약

Refresh Token을 사용한 Access Token 갱신 API를 구현했습니다. 보안을 위해 Refresh Token Rotation 정책을 적용했습니다.

### 주요 변경사항
- 토큰 갱신 API 엔드포인트 추가 (POST /v1/auth/token/refresh)
- Refresh Token Rotation 구현
- CookieUtil 유틸리티 클래스 추가
- TokenRefreshResponse DTO 추가
- 토큰 갱신 관련 에러 코드 추가

## 🎯 변경 목적

사용자의 Access Token이 만료되었을 때, Refresh Token을 사용하여 새로운 Access Token을 발급받을 수 있도록 합니다. Refresh Token Rotation을 통해 보안을 강화합니다.

## 🔍 변경 내역 상세

### 추가된 기능 (Features)

- [x] **토큰 갱신 API**: POST /v1/auth/token/refresh
  - `AuthController.refreshToken()`: 토큰 갱신 엔드포인트
  - `AuthService.refreshToken()`: 토큰 갱신 비즈니스 로직
  - HttpOnly 쿠키에서 Refresh Token 추출 및 검증
  - 새로운 Access Token과 Refresh Token 발급
  - Refresh Token Rotation 적용

- [x] **TokenRefreshResponse DTO**: 토큰 갱신 응답
  - `accessToken`: 새로 발급된 Access Token
  - `expiresIn`: Access Token 만료 시간 (초)

- [x] **CookieUtil 유틸리티**: HTTP 쿠키 관리
  - `createCookie()`: 쿠키 생성 (HttpOnly, Secure 플래그 지원)
  - `getCookieValue()`: 쿠키 값 조회
  - `deleteCookie()`: 쿠키 삭제

- [x] **에러 코드 추가**: AuthErrorCode
  - `REFRESH_TOKEN_NOT_FOUND`: Refresh Token이 쿠키에 없음
  - `REFRESH_TOKEN_INVALID`: Refresh Token이 유효하지 않음
  - `REFRESH_TOKEN_MISMATCH`: DB의 Refresh Token과 불일치

### 기타 변경사항 (Others)

- [x] **JwtTokenProvider 개선**: Refresh Token 추출 메서드 추가
- [x] **보안 강화**: Refresh Token Rotation으로 토큰 탈취 위험 감소

## 🧪 테스트 방법

### API 테스트 예시

**1. 로그인하여 Refresh Token 획득**
```bash
curl -X POST http://localhost:8080/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{
    "userId": "test_user",
    "password": "password123"
  }' \
  -c cookies.txt
```

**2. Refresh Token으로 Access Token 갱신**
```bash
curl -X POST http://localhost:8080/api/v1/auth/token/refresh \
  -b cookies.txt \
  -c cookies_new.txt
```

**예상 결과:**
```json
{
  "success": true,
  "message": "토큰이 성공적으로 갱신되었습니다",
  "data": {
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "expiresIn": 3600
  }
}
```

**3. 만료된 Refresh Token으로 재요청 시 에러**
```bash
curl -X POST http://localhost:8080/api/v1/auth/token/refresh \
  -b cookies.txt
```

**예상 결과:**
```json
{
  "success": false,
  "message": "유효하지 않은 Refresh Token입니다",
  "data": null
}
```

### 단위 테스트
- [ ] AuthService.refreshToken() 테스트 작성 예정
- [ ] CookieUtil 테스트 작성 예정

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

기존 로그인 API와 독립적으로 동작하며, 기존 기능에 영향을 주지 않습니다.

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

기존 `users` 테이블의 `refresh_token` 필드를 활용합니다.

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거
- [x] 로그 레벨 적절히 설정

### 테스트
- [ ] 단위 테스트 작성 완료 (다음 PR에서 추가 예정)
- [ ] 통합 테스트 작성 완료
- [x] 수동 테스트 통과
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] Refresh Token Rotation 적용
- [x] HttpOnly, Secure 쿠키 플래그 사용
- [x] SHA-256 해시로 DB에 저장
- [x] 토큰 검증 로직 추가
- [x] 민감 정보 노출 검토

### 성능
- [x] 불필요한 DB 쿼리 최적화
- [x] 적절한 인덱스 사용 확인

### 문서
- [x] API 문서 업데이트 (Swagger 주석)
- [x] 코드 주석 작성 (복잡한 로직만)
- [ ] Jira Story 상태 업데이트 (리뷰 후 진행)

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: BU-142`)
- [x] develop 브랜치 최신 코드 반영
- [x] 충돌 해결 완료

## 📌 리뷰어에게

**특히 확인 부탁드리는 부분:**
1. Refresh Token Rotation 로직이 안전하게 구현되었는지 확인
2. CookieUtil의 쿠키 설정 (HttpOnly, Secure, Path)이 적절한지 확인
3. 에러 처리가 누락된 케이스가 없는지 확인
4. 단위 테스트가 필요한 부분 피드백 부탁드립니다

**Refresh Token Rotation 흐름:**
1. 클라이언트가 기존 Refresh Token으로 갱신 요청
2. 서버가 Refresh Token 검증
3. 새로운 Access Token과 Refresh Token 발급
4. 기존 Refresh Token은 DB에서 교체됨 (일회용)
5. 클라이언트는 새로운 Refresh Token을 쿠키로 받음

## 🔗 관련 PR/Issue
- Related Issue: BU-142 (토큰 갱신 API 구현)
- Related PR: #52 (로그인 API 구현)

---

## 📚 참고 자료
- [RFC 6749 - OAuth 2.0 Refresh Token](https://datatracker.ietf.org/doc/html/rfc6749#section-1.5)
- [OWASP - Token Handling Best Practices](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html)

[BU-142]: https://build-up-project.atlassian.net/browse/BU-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 토큰 재발급(리프레시) 엔드포인트 추가로 액세스 토큰 갱신 지원 및 리프레시 토큰 회전 적용.
  * HttpOnly·Secure 쿠키를 통한 리프레시 토큰 설정 및 삭제 처리 개선.

* **에러 처리**
  * 리프레시 토큰 관련 검증 실패, 불일치, 만료, 미존재 등 새로운 인증 에러코드 추가로 오류 응답 명확화.

* **테스트**
  * 리프레시 흐름과 쿠키 유틸 동작을 검증하는 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->