### PR TITLE
feature/BU-154: 현장 등록 시스템 구현 (BU-154)

### DIFF
--- a/.claude/ERD.md
+++ b/.claude/ERD.md
@@ -361,6 +361,9 @@ Build-Up Platform 데이터베이스 구조 설계 문서입니다.
 | `id` | BIGINT | PK, AUTO_INCREMENT | 현장 ID |
 | `site_name` | VARCHAR(100) | NOT NULL | 현장명 |
 | `site_address` | VARCHAR(255) | NULL | 현장 주소 |
+| `client_name` | VARCHAR(100) | NULL | 발주처 (클라이언트) |
+| `start_date` | DATE | NULL | 공사 시작일 |
+| `end_date` | DATE | NULL | 공사 종료일 |
 | `corporation_id` | BIGINT | FK, NULL | 소속 기업 ID |
 | `manager_id` | BIGINT | FK, NULL | 현장 관리자 ID |
 | `manager_secret_key` | VARCHAR(100) | UNIQUE, NULL | 현장 관리자용 시크릿키 (회원가입용) |
@@ -872,5 +875,6 @@ ON work_reports(work_report_status);
 | 2025-11-15 | payrolls 테이블 컬럼 추가 (salary_year, salary_month, salary_week, salary_day, s3_key, generated_at) 및 중복 방지 UNIQUE INDEX 추가 (급여명세서 자동 생성 기능) | 문현민 |
 | 2025-11-12 | users 테이블 phone 컬럼 제약조건 변경 (NOT NULL → NULL, 2단계 회원가입 지원) | 김세원 |
 | 2025-11-16 | attendances 테이블 is_late 컬럼 추가 (계약서 기반 지각 판단, 출근 시간 +5분 초과 시 true) | 김세원 |
+| 2025-11-17 | sites 테이블에 client_name, start_date, end_date 컬럼 추가 (현장 등록 API 구현) | 김세원 |
 
 ---

--- a/.claude/ERD.md
+++ b/.claude/ERD.md
@@ -876,5 +876,6 @@ ON work_reports(work_report_status);
 | 2025-11-12 | users 테이블 phone 컬럼 제약조건 변경 (NOT NULL → NULL, 2단계 회원가입 지원) | 김세원 |
 | 2025-11-16 | attendances 테이블 is_late 컬럼 추가 (계약서 기반 지각 판단, 출근 시간 +5분 초과 시 true) | 김세원 |
 | 2025-11-17 | sites 테이블에 client_name, start_date, end_date 컬럼 추가 (현장 등록 API 구현) | 김세원 |
+| 2025-11-17 | sites 테이블 manager_id nullable 명시화 및 데이터베이스 스키마 수정 (현장 등록 시점에는 manager 미할당, 추후 할당 가능) | 김세원 |
 
 ---

--- a/docker/mysql/init/02-insert-sample-data.sql
+++ b/docker/mysql/init/02-insert-sample-data.sql
@@ -7,10 +7,10 @@ USE buildup;
 -- 1. 역할(Roles) 삽입
 -- ============================================
 INSERT INTO roles (role_name, description, is_deleted) VALUES
-    ('ADMIN', '시스템 관리자', b'0'),
-    ('MANAGER', '현장 관리자', b'0'),
-    ('EMPLOYEE', '근로자', b'0'),
-    ('CORPORATION', '기업', b'0')
+    ('ROLE_ADMIN', '시스템 관리자', b'0'),
+    ('ROLE_MANAGER', '현장 관리자', b'0'),
+    ('ROLE_EMPLOYEE', '근로자', b'0'),
+    ('ROLE_CORPORATION', '기업', b'0')
 ON DUPLICATE KEY UPDATE
     description = VALUES(description),
     is_deleted = VALUES(is_deleted);
@@ -22,7 +22,7 @@ ON DUPLICATE KEY UPDATE
 INSERT INTO users (user_id, password, role_id, phone, email, secret_key, profile_completed, is_deleted)
 SELECT 'admin', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', r.id, NULL, 'admin@buildup.com', NULL, b'1', b'0'
 FROM roles r
-WHERE r.role_name = 'ADMIN'
+WHERE r.role_name = 'ROLE_ADMIN'
 ON DUPLICATE KEY UPDATE
     password = VALUES(password),
     email = VALUES(email);

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -106,9 +106,9 @@ public class AuthService {
         }
 
         // 3. 역할 조회 (EMPLOYEE)
-        Role employeeRole = roleRepository.findByRoleName("EMPLOYEE")
+        Role employeeRole = roleRepository.findByRoleName("ROLE_EMPLOYEE")
                 .orElseThrow(() -> {
-                    log.error("EMPLOYEE 역할을 찾을 수 없습니다");
+                    log.error("ROLE_EMPLOYEE 역할을 찾을 수 없습니다");
                     return new BusinessException(AuthErrorCode.ROLE_NOT_FOUND);
                 });
 
@@ -192,9 +192,9 @@ public class AuthService {
         }
 
         // 4. 역할 조회 (EMPLOYEE)
-        Role employeeRole = roleRepository.findByRoleName("EMPLOYEE")
+        Role employeeRole = roleRepository.findByRoleName("ROLE_EMPLOYEE")
                 .orElseThrow(() -> {
-                    log.error("EMPLOYEE 역할을 찾을 수 없습니다");
+                    log.error("ROLE_EMPLOYEE 역할을 찾을 수 없습니다");
                     return new BusinessException(AuthErrorCode.ROLE_NOT_FOUND);
                 });
 
@@ -359,9 +359,9 @@ public class AuthService {
         }
 
         // 6. 역할 조회 (MANAGER)
-        Role managerRole = roleRepository.findByRoleName("MANAGER")
+        Role managerRole = roleRepository.findByRoleName("ROLE_MANAGER")
                 .orElseThrow(() -> {
-                    log.error("MANAGER 역할을 찾을 수 없습니다");
+                    log.error("ROLE_MANAGER 역할을 찾을 수 없습니다");
                     return new BusinessException(AuthErrorCode.ROLE_NOT_FOUND);
                 });
 
@@ -593,7 +593,7 @@ public class AuthService {
         String name = null;
 
         switch (roleName) {
-            case "EMPLOYEE":
+            case "ROLE_EMPLOYEE":
                 // 근로자 정보 조회
                 Employee employee = employeeRepository.findByUser(user)
                         .orElseThrow(() -> {
@@ -629,7 +629,7 @@ public class AuthService {
                         .build();
                 break;
 
-            case "MANAGER":
+            case "ROLE_MANAGER":
                 // 현장 관리자 정보 조회
                 Manager manager = managerRepository.findByUser(user)
                         .orElseThrow(() -> {
@@ -658,7 +658,7 @@ public class AuthService {
                         .build();
                 break;
 
-            case "CORPORATION":
+            case "ROLE_CORPORATION":
                 // 기업 정보 조회
                 Corporation corporation = corporationRepository.findByUserId(user.getId())
                         .orElseThrow(() -> {

--- a/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
+++ b/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
@@ -1,0 +1,65 @@
+package com.concrete.buildup.domain.site.controller;
+
+import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
+import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
+import com.concrete.buildup.domain.site.service.SiteService;
+import com.concrete.buildup.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 현장 관리 컨트롤러
+ *
+ * <p>현장 등록, 조회 등 현장 관리 API를 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Slf4j
+@RestController
+@RequestMapping("/v1/sites")
+@RequiredArgsConstructor
+@Tag(name = "Site", description = "현장 관리 API")
+public class SiteController {
+
+    private final SiteService siteService;
+
+    /**
+     * 현장 등록 API
+     *
+     * <p>CORPORATION 권한 사용자가 새로운 건설 현장을 등록합니다.</p>
+     * <p>현장 등록 시 자동으로 현장 관리자용/근로자용 시크릿키가 생성됩니다.</p>
+     *
+     * @param request 현장 등록 요청 정보 (현장명, 주소, 발주처, 공사 기간)
+     * @return SiteCreateResponse - 생성된 현장 정보 및 시크릿키
+     */
+    @Operation(
+            summary = "현장 등록",
+            description = "CORPORATION 권한 사용자가 새로운 건설 현장을 등록합니다. " +
+                    "현장 등록 시 자동으로 현장 관리자용 시크릿키와 근로자용 시크릿키가 생성됩니다. " +
+                    "생성된 시크릿키는 해당 현장의 관리자/근로자 회원가입 시 사용됩니다."
+    )
+    @PostMapping
+    @PreAuthorize("hasRole('CORPORATION')")
+    public ResponseEntity<ApiResponse<SiteCreateResponse>> createSite(
+            @Valid @RequestBody SiteCreateRequest request
+    ) {
+        log.info("현장 등록 API 호출: siteName={}", request.getSiteName());
+
+        SiteCreateResponse response = siteService.createSite(request);
+
+        log.info("현장 등록 완료: siteId={}, managerSecretKey={}, employeeSecretKey={}",
+                response.getSiteId(), response.getManagerSecretKey(), response.getEmployeeSecretKey());
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "현장이 성공적으로 등록되었습니다"));
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
+++ b/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
@@ -4,6 +4,7 @@ import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
 import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
 import com.concrete.buildup.domain.site.service.SiteService;
 import com.concrete.buildup.global.common.ApiResponse;
+import com.concrete.buildup.global.util.MaskingUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -56,7 +57,9 @@ public class SiteController {
         SiteCreateResponse response = siteService.createSite(request);
 
         log.info("현장 등록 완료: siteId={}, managerSecretKey={}, employeeSecretKey={}",
-                response.getSiteId(), response.getManagerSecretKey(), response.getEmployeeSecretKey());
+                response.getSiteId(),
+                MaskingUtil.maskSecretKey(response.getManagerSecretKey()),
+                MaskingUtil.maskSecretKey(response.getEmployeeSecretKey()));
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/com/concrete/buildup/domain/site/dto/SiteCreateRequest.java
+++ b/src/main/java/com/concrete/buildup/domain/site/dto/SiteCreateRequest.java
@@ -1,0 +1,43 @@
+package com.concrete.buildup.domain.site.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 현장 생성 요청 DTO
+ *
+ * <p>건설 현장 등록 시 사용되는 요청 DTO입니다.</p>
+ * <p>기업 관리자가 새로운 현장을 등록할 때 사용합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "현장 등록 요청")
+public class SiteCreateRequest {
+
+    @NotBlank(message = "현장명은 필수입니다")
+    @Schema(description = "현장명", example = "강남 재개발 현장", required = true)
+    private String siteName;
+
+    @Schema(description = "현장 주소", example = "서울시 강남구 테헤란로 123")
+    private String siteAddress;
+
+    @Schema(description = "발주처 (클라이언트)", example = "서울시청")
+    private String clientName;
+
+    @Schema(description = "공사 시작일", example = "2025-01-01")
+    private LocalDate startDate;
+
+    @Schema(description = "공사 종료일", example = "2025-12-31")
+    private LocalDate endDate;
+}

--- a/src/main/java/com/concrete/buildup/domain/site/dto/SiteCreateResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/site/dto/SiteCreateResponse.java
@@ -1,0 +1,66 @@
+package com.concrete.buildup.domain.site.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+/**
+ * 현장 생성 응답 DTO
+ *
+ * <p>현장 등록 성공 시 반환되는 응답 DTO입니다.</p>
+ * <p>생성된 현장 정보와 시크릿키 정보를 포함합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(description = "현장 등록 응답")
+public class SiteCreateResponse {
+
+    @Schema(description = "현장 ID", example = "1")
+    private Long siteId;
+
+    @Schema(description = "현장명", example = "강남 재개발 현장")
+    private String siteName;
+
+    @Schema(description = "현장 주소", example = "서울시 강남구 테헤란로 123")
+    private String siteAddress;
+
+    @Schema(description = "발주처 (클라이언트)", example = "서울시청")
+    private String clientName;
+
+    @Schema(description = "공사 시작일", example = "2025-01-01")
+    private LocalDate startDate;
+
+    @Schema(description = "공사 종료일", example = "2025-12-31")
+    private LocalDate endDate;
+
+    @Schema(description = "현장 관리자용 시크릿키", example = "CONC-1-XYZ-9205")
+    private String managerSecretKey;
+
+    @Schema(description = "근로자용 시크릿키", example = "CONC-1-ABC-1234")
+    private String employeeSecretKey;
+
+    /**
+     * Entity로부터 응답 DTO 생성
+     */
+    public static SiteCreateResponse of(Long siteId, String siteName, String siteAddress,
+                                         String clientName, LocalDate startDate, LocalDate endDate,
+                                         String managerSecretKey, String employeeSecretKey) {
+        return SiteCreateResponse.builder()
+            .siteId(siteId)
+            .siteName(siteName)
+            .siteAddress(siteAddress)
+            .clientName(clientName)
+            .startDate(startDate)
+            .endDate(endDate)
+            .managerSecretKey(managerSecretKey)
+            .employeeSecretKey(employeeSecretKey)
+            .build();
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/entity/Site.java
+++ b/src/main/java/com/concrete/buildup/domain/site/entity/Site.java
@@ -6,6 +6,7 @@ import com.concrete.buildup.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
@@ -34,6 +35,24 @@ public class Site extends BaseEntity {
      */
     @Column(name = "site_address", length = 255)
     private String siteAddress;
+
+    /**
+     * 발주처 (클라이언트)
+     */
+    @Column(name = "client_name", length = 100)
+    private String clientName;
+
+    /**
+     * 공사 시작일
+     */
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    /**
+     * 공사 종료일
+     */
+    @Column(name = "end_date")
+    private LocalDate endDate;
 
     /**
      * 소속 기업
@@ -82,12 +101,22 @@ public class Site extends BaseEntity {
     /**
      * 현장 정보 수정
      */
-    public void updateSiteInfo(String siteName, String siteAddress) {
+    public void updateSiteInfo(String siteName, String siteAddress, String clientName,
+                               LocalDate startDate, LocalDate endDate) {
         if (siteName != null) {
             this.siteName = siteName;
         }
         if (siteAddress != null) {
             this.siteAddress = siteAddress;
+        }
+        if (clientName != null) {
+            this.clientName = clientName;
+        }
+        if (startDate != null) {
+            this.startDate = startDate;
+        }
+        if (endDate != null) {
+            this.endDate = endDate;
         }
     }
 
@@ -96,5 +125,23 @@ public class Site extends BaseEntity {
      */
     public void assignManager(Manager manager) {
         this.manager = manager;
+    }
+
+    /**
+     * Secret Key 설정
+     */
+    public void setSecretKeys(String managerSecretKey, String employeeSecretKey) {
+        this.managerSecretKey = managerSecretKey;
+        this.employeeSecretKey = employeeSecretKey;
+    }
+
+    /**
+     * 공사 기간 유효성 검증
+     */
+    public boolean isDateRangeValid() {
+        if (startDate == null || endDate == null) {
+            return true; // NULL은 허용
+        }
+        return !startDate.isAfter(endDate);
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/site/entity/Site.java
+++ b/src/main/java/com/concrete/buildup/domain/site/entity/Site.java
@@ -63,9 +63,10 @@ public class Site extends BaseEntity {
 
     /**
      * 현장 관리자
+     * (현장 등록 시점에는 null, 추후 할당 가능)
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "manager_id")
+    @JoinColumn(name = "manager_id", nullable = true)
     private Manager manager;
 
     /**

--- a/src/main/java/com/concrete/buildup/domain/site/repository/SiteRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/site/repository/SiteRepository.java
@@ -38,4 +38,20 @@ public interface SiteRepository extends JpaRepository<Site, Long> {
      */
     @Query("SELECT s FROM Site s JOIN s.manager m WHERE m.user.id = :userId")
     Optional<Site> findByManagerUserId(@Param("userId") Long userId);
+
+    /**
+     * 현장 관리자용 시크릿키 중복 확인
+     *
+     * @param managerSecretKey 현장 관리자용 시크릿키
+     * @return 존재 여부
+     */
+    boolean existsByManagerSecretKey(String managerSecretKey);
+
+    /**
+     * 근로자용 시크릿키 중복 확인
+     *
+     * @param employeeSecretKey 근로자용 시크릿키
+     * @return 존재 여부
+     */
+    boolean existsByEmployeeSecretKey(String employeeSecretKey);
 }

--- a/src/main/java/com/concrete/buildup/domain/site/service/SecretKeyService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SecretKeyService.java
@@ -1,0 +1,71 @@
+package com.concrete.buildup.domain.site.service;
+
+import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.global.util.SecretKeyGenerator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 시크릿키 생성 서비스
+ *
+ * 현장 등록 시 중복되지 않는 시크릿키를 생성합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class SecretKeyService {
+
+    private static final int MAX_RETRY = 10;
+
+    private final SiteRepository siteRepository;
+
+    /**
+     * 유니크한 시크릿키 쌍 생성
+     *
+     * @param corpName 기업명
+     * @param siteId 현장 ID
+     * @return 생성된 시크릿키 쌍
+     * @throws IllegalStateException 최대 재시도 횟수 초과 시
+     */
+    public SecretKeyPair generateUniqueSecretKeys(String corpName, Long siteId) {
+        int attempt = 0;
+
+        while (attempt < MAX_RETRY) {
+            attempt++;
+
+            // 시크릿키 생성
+            String managerSecretKey = SecretKeyGenerator.generateManagerSecretKey(corpName, siteId);
+            String employeeSecretKey = SecretKeyGenerator.generateEmployeeSecretKey(corpName, siteId);
+
+            // 중복 확인
+            boolean managerKeyExists = siteRepository.existsByManagerSecretKey(managerSecretKey);
+            boolean employeeKeyExists = siteRepository.existsByEmployeeSecretKey(employeeSecretKey);
+
+            if (!managerKeyExists && !employeeKeyExists) {
+                log.info("유니크한 시크릿키 생성 성공 - 시도 횟수: {}, siteId: {}", attempt, siteId);
+                return new SecretKeyPair(managerSecretKey, employeeSecretKey);
+            }
+
+            log.warn("시크릿키 중복 발생 - 시도 횟수: {}, siteId: {}, managerKeyExists: {}, employeeKeyExists: {}",
+                attempt, siteId, managerKeyExists, employeeKeyExists);
+        }
+
+        log.error("유니크한 시크릿키 생성 실패 - 최대 재시도 횟수 초과, siteId: {}", siteId);
+        throw new IllegalStateException("유니크한 시크릿키 생성에 실패했습니다. 최대 재시도 횟수를 초과했습니다.");
+    }
+
+    /**
+     * 시크릿키 쌍 DTO
+     */
+    @Getter
+    @AllArgsConstructor
+    public static class SecretKeyPair {
+        private final String managerSecretKey;
+        private final String employeeSecretKey;
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/service/SecretKeyService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SecretKeyService.java
@@ -1,6 +1,7 @@
 package com.concrete.buildup.domain.site.service;
 
 import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.global.exception.SecretKeyGenerationException;
 import com.concrete.buildup.global.util.SecretKeyGenerator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,33 +31,56 @@ public class SecretKeyService {
      * @param corpName 기업명
      * @param siteId 현장 ID
      * @return 생성된 시크릿키 쌍
-     * @throws IllegalStateException 최대 재시도 횟수 초과 시
+     * @throws SecretKeyGenerationException 최대 재시도 횟수 초과 시
      */
     public SecretKeyPair generateUniqueSecretKeys(String corpName, Long siteId) {
         int attempt = 0;
+        String managerSecretKey = null;
+        String employeeSecretKey = null;
+        boolean regenerateManager = true;
+        boolean regenerateEmployee = true;
 
         while (attempt < MAX_RETRY) {
             attempt++;
 
-            // 시크릿키 생성
-            String managerSecretKey = SecretKeyGenerator.generateManagerSecretKey(corpName, siteId);
-            String employeeSecretKey = SecretKeyGenerator.generateEmployeeSecretKey(corpName, siteId);
+            // 첫 번째 시도 또는 충돌 발생한 키만 재생성
+            if (regenerateManager) {
+                managerSecretKey = SecretKeyGenerator.generateManagerSecretKey(corpName, siteId);
+            }
+            if (regenerateEmployee) {
+                employeeSecretKey = SecretKeyGenerator.generateEmployeeSecretKey(corpName, siteId);
+            }
 
-            // 중복 확인
-            boolean managerKeyExists = siteRepository.existsByManagerSecretKey(managerSecretKey);
-            boolean employeeKeyExists = siteRepository.existsByEmployeeSecretKey(employeeSecretKey);
+            // 재생성된 키만 중복 확인
+            boolean managerKeyExists = regenerateManager && siteRepository.existsByManagerSecretKey(managerSecretKey);
+            boolean employeeKeyExists = regenerateEmployee && siteRepository.existsByEmployeeSecretKey(employeeSecretKey);
 
+            // 두 키 모두 유니크하면 성공
             if (!managerKeyExists && !employeeKeyExists) {
                 log.info("유니크한 시크릿키 생성 성공 - 시도 횟수: {}, siteId: {}", attempt, siteId);
                 return new SecretKeyPair(managerSecretKey, employeeSecretKey);
             }
 
-            log.warn("시크릿키 중복 발생 - 시도 횟수: {}, siteId: {}, managerKeyExists: {}, employeeKeyExists: {}",
-                attempt, siteId, managerKeyExists, employeeKeyExists);
+            // 다음 반복에서 재생성할 키 결정
+            regenerateManager = managerKeyExists;
+            regenerateEmployee = employeeKeyExists;
+
+            // 재생성할 키에 대한 로그 출력
+            String regenerationTarget;
+            if (managerKeyExists && employeeKeyExists) {
+                regenerationTarget = "관리자키, 근로자키";
+            } else if (managerKeyExists) {
+                regenerationTarget = "관리자키";
+            } else {
+                regenerationTarget = "근로자키";
+            }
+
+            log.warn("시크릿키 중복 발생 - 시도 횟수: {}, siteId: {}, 재생성 대상: {}",
+                    attempt, siteId, regenerationTarget);
         }
 
         log.error("유니크한 시크릿키 생성 실패 - 최대 재시도 횟수 초과, siteId: {}", siteId);
-        throw new IllegalStateException("유니크한 시크릿키 생성에 실패했습니다. 최대 재시도 횟수를 초과했습니다.");
+        throw new SecretKeyGenerationException("유니크한 시크릿키 생성에 실패했습니다. 최대 재시도 횟수를 초과했습니다.");
     }
 
     /**

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -1,0 +1,105 @@
+package com.concrete.buildup.domain.site.service;
+
+import com.concrete.buildup.domain.auth.entity.Corporation;
+import com.concrete.buildup.domain.auth.entity.User;
+import com.concrete.buildup.domain.auth.repository.CorporationRepository;
+import com.concrete.buildup.domain.auth.repository.UserRepository;
+import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
+import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
+import com.concrete.buildup.domain.site.entity.Site;
+import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.global.exception.BusinessException;
+import com.concrete.buildup.global.exception.errorcode.AuthErrorCode;
+import com.concrete.buildup.global.exception.errorcode.SiteErrorCode;
+import com.concrete.buildup.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 현장 관리 서비스
+ *
+ * <p>현장 등록, 조회 등 현장 관리 기능을 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class SiteService {
+
+    private final SiteRepository siteRepository;
+    private final UserRepository userRepository;
+    private final CorporationRepository corporationRepository;
+    private final SecretKeyService secretKeyService;
+
+    /**
+     * 현장 등록
+     *
+     * <p>CORPORATION 권한 사용자가 새로운 현장을 등록합니다.</p>
+     * <p>현장 등록 시 자동으로 managerSecretKey와 employeeSecretKey가 생성됩니다.</p>
+     *
+     * @param request 현장 등록 요청 DTO
+     * @return 현장 등록 응답 DTO (생성된 현장 정보 + 시크릿키 포함)
+     * @throws BusinessException 사용자 미인증, 기업 정보 없음, 날짜 범위 오류 시
+     */
+    @Transactional
+    public SiteCreateResponse createSite(SiteCreateRequest request) {
+        // 1. 현재 인증된 사용자 조회
+        String currentUserId = SecurityUtil.getCurrentUserId();
+        User user = userRepository.findByUserId(currentUserId)
+            .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 2. 사용자의 기업 정보 조회
+        Corporation corporation = corporationRepository.findByUserId(user.getId())
+            .orElseThrow(() -> new BusinessException(SiteErrorCode.CORPORATION_NOT_FOUND));
+
+        // 3. 임시 Site 생성 (ID 생성을 위해 먼저 저장)
+        Site site = Site.builder()
+            .siteName(request.getSiteName())
+            .siteAddress(request.getSiteAddress())
+            .clientName(request.getClientName())
+            .startDate(request.getStartDate())
+            .endDate(request.getEndDate())
+            .corporation(corporation)
+            .build();
+
+        // 4. 날짜 범위 검증
+        if (!site.isDateRangeValid()) {
+            throw new BusinessException(SiteErrorCode.INVALID_DATE_RANGE);
+        }
+
+        // 5. 임시 저장하여 ID 생성 (시크릿키 생성에 필요)
+        Site savedSite = siteRepository.save(site);
+
+        // 6. 유니크한 시크릿키 생성
+        SecretKeyService.SecretKeyPair secretKeyPair = secretKeyService.generateUniqueSecretKeys(
+            corporation.getCorpName(),
+            savedSite.getId()
+        );
+
+        // 7. 생성된 시크릿키 설정
+        savedSite.setSecretKeys(
+            secretKeyPair.getManagerSecretKey(),
+            secretKeyPair.getEmployeeSecretKey()
+        );
+
+        log.info("현장 등록 완료 - siteId: {}, siteName: {}, corporation: {}",
+            savedSite.getId(), savedSite.getSiteName(), corporation.getCorpName());
+
+        // 8. 응답 DTO 생성
+        return SiteCreateResponse.of(
+            savedSite.getId(),
+            savedSite.getSiteName(),
+            savedSite.getSiteAddress(),
+            savedSite.getClientName(),
+            savedSite.getStartDate(),
+            savedSite.getEndDate(),
+            secretKeyPair.getManagerSecretKey(),
+            secretKeyPair.getEmployeeSecretKey()
+        );
+    }
+}

--- a/src/main/java/com/concrete/buildup/global/config/SecurityConfig.java
+++ b/src/main/java/com/concrete/buildup/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -21,6 +22,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -84,6 +86,9 @@ public class SecurityConfig {
                 .accessDeniedHandler(jwtAccessDeniedHandler)
             )
             .authorizeHttpRequests(auth -> auth
+                // CORS Preflight 요청 (OPTIONS) 허용 - 가장 먼저 처리
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
                 // 인증 필요한 Auth API
                 .requestMatchers("/v1/auth/me").authenticated()
 
@@ -139,11 +144,18 @@ public class SecurityConfig {
         // 운영 환경에서는 특정 도메인으로 제한 필요
         configuration.addAllowedOriginPattern("*");
 
-        // 모든 HTTP 메서드 허용
-        configuration.addAllowedMethod("*");
+        // 허용할 HTTP 메서드 명시 (OPTIONS 포함)
+        configuration.setAllowedMethods(Arrays.asList(
+            "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"
+        ));
 
         // 모든 헤더 허용
         configuration.addAllowedHeader("*");
+
+        // 클라이언트에 노출할 헤더 명시
+        configuration.setExposedHeaders(Arrays.asList(
+            "Authorization", "Content-Type", "X-Requested-With"
+        ));
 
         // 인증 정보 포함 허용 (JWT, 쿠키 등)
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/concrete/buildup/global/config/WebConfig.java
+++ b/src/main/java/com/concrete/buildup/global/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.concrete.buildup.global.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -14,12 +15,28 @@ import java.util.List;
 
 /**
  * Web MVC 설정
+ * - CORS 설정
  * - HTTP Message Converter 설정
  * - Interceptor 설정
  * - 기타 웹 관련 설정
  */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    /**
+     * CORS 매핑 설정 (글로벌)
+     * SecurityConfig의 CORS 설정과 함께 작동하여 이중 보장
+     */
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD")
+                .allowedHeaders("*")
+                .exposedHeaders("Authorization", "Content-Type", "X-Requested-With")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
 
     /**
      * Interceptor 등록

--- a/src/main/java/com/concrete/buildup/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/concrete/buildup/global/exception/GlobalExceptionHandler.java
@@ -330,8 +330,23 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * SecretKeyGenerationException 처리
+     * 시크릿키 생성 실패 시 발생하는 예외를 처리합니다.
+     */
+    @ExceptionHandler(SecretKeyGenerationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleSecretKeyGenerationException(SecretKeyGenerationException e) {
+        log.error("[SecretKeyGenerationException] Secret key generation failed: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(
+                        "시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+                        "COMMON_500"));
+    }
+
+    /**
      * IllegalStateException 처리
-     * 시크릿키 생성 실패 등 시스템 상태 오류 시 발생하는 예외를 처리합니다.
+     * 시스템 상태 오류 시 발생하는 예외를 처리합니다.
      */
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalStateException(IllegalStateException e) {

--- a/src/main/java/com/concrete/buildup/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/concrete/buildup/global/exception/GlobalExceptionHandler.java
@@ -330,6 +330,21 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * IllegalStateException 처리
+     * 시크릿키 생성 실패 등 시스템 상태 오류 시 발생하는 예외를 처리합니다.
+     */
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalStateException(IllegalStateException e) {
+        log.error("[IllegalStateException] System state error: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(
+                        "시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+                        "COMMON_500"));
+    }
+
+    /**
      * 예상치 못한 예외 처리
      * 모든 예외의 최종 처리자입니다.
      */

--- a/src/main/java/com/concrete/buildup/global/exception/SecretKeyGenerationException.java
+++ b/src/main/java/com/concrete/buildup/global/exception/SecretKeyGenerationException.java
@@ -1,0 +1,28 @@
+package com.concrete.buildup.global.exception;
+
+/**
+ * 시크릿키 생성 실패 예외
+ *
+ * <p>현장 등록 시 유니크한 시크릿키 생성에 실패했을 때 발생하는 예외입니다.</p>
+ * <p>주로 최대 재시도 횟수를 초과했을 때 발생합니다.</p>
+ *
+ * <p>사용 예시:</p>
+ * <pre>
+ * if (attempt >= MAX_RETRY) {
+ *     throw new SecretKeyGenerationException("유니크한 시크릿키 생성에 실패했습니다.");
+ * }
+ * </pre>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+public class SecretKeyGenerationException extends RuntimeException {
+
+    public SecretKeyGenerationException(String message) {
+        super(message);
+    }
+
+    public SecretKeyGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/concrete/buildup/global/exception/errorcode/SiteErrorCode.java
+++ b/src/main/java/com/concrete/buildup/global/exception/errorcode/SiteErrorCode.java
@@ -23,7 +23,11 @@ public enum SiteErrorCode implements BaseErrorCode {
     SECRET_KEY_ALREADY_USED(HttpStatus.CONFLICT, 3002, "이미 사용 중인 시크릿키입니다."),
 
     // 404 Not Found
-    SITE_NOT_FOUND(HttpStatus.NOT_FOUND, 3003, "현장을 찾을 수 없습니다.");
+    SITE_NOT_FOUND(HttpStatus.NOT_FOUND, 3003, "현장을 찾을 수 없습니다."),
+    CORPORATION_NOT_FOUND(HttpStatus.NOT_FOUND, 3004, "기업 정보를 찾을 수 없습니다."),
+
+    // 400 Bad Request
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, 3005, "공사 종료일은 시작일보다 이후여야 합니다.");
 
     private final HttpStatus httpStatus;
     private final int codeNumber;

--- a/src/main/java/com/concrete/buildup/global/util/MaskingUtil.java
+++ b/src/main/java/com/concrete/buildup/global/util/MaskingUtil.java
@@ -116,4 +116,39 @@ public final class MaskingUtil {
         // 중간 부분 마스킹
         return parts[0] + "-" + MASK_CHARACTER.repeat(parts[1].length()) + "-" + parts[2];
     }
+
+    /**
+     * 시크릿키 마스킹
+     *
+     * <p>시크릿키의 앞부분을 마스킹 처리하고 마지막 4자리만 표시합니다.</p>
+     * <p>보안상 중요한 정보를 로그에 남길 때 사용됩니다.</p>
+     *
+     * <p>예시:</p>
+     * <ul>
+     *   <li>"abc123def456ghi789" → "**************i789"</li>
+     *   <li>"short" → "*hort"</li>
+     *   <li>null → null</li>
+     *   <li>"" → ""</li>
+     * </ul>
+     *
+     * @param secretKey 시크릿키
+     * @return 마스킹된 시크릿키 (마지막 4자리만 표시)
+     */
+    public static String maskSecretKey(String secretKey) {
+        if (secretKey == null || secretKey.isEmpty()) {
+            return secretKey;
+        }
+
+        int length = secretKey.length();
+
+        // 4자 이하인 경우: 첫 글자만 마스킹
+        if (length <= 4) {
+            return MASK_CHARACTER + secretKey.substring(1);
+        }
+
+        // 5자 이상인 경우: 마지막 4자리만 표시
+        int visibleLength = 4;
+        int maskLength = length - visibleLength;
+        return MASK_CHARACTER.repeat(maskLength) + secretKey.substring(maskLength);
+    }
 }

--- a/src/main/java/com/concrete/buildup/global/util/SecretKeyGenerator.java
+++ b/src/main/java/com/concrete/buildup/global/util/SecretKeyGenerator.java
@@ -1,0 +1,117 @@
+package com.concrete.buildup.global.util;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+/**
+ * 현장 시크릿키 생성 유틸리티
+ *
+ * 현장 등록 시 현장 관리자/근로자용 시크릿키를 생성합니다.
+ * 형식: {기업명앞4글자대문자}-{siteId}-{randomString}-{randomNumber}
+ * 예시: CONC-2039-XYZ-9205
+ */
+public class SecretKeyGenerator {
+
+    private static final String DEFAULT_PREFIX = "SITE";
+    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final int PREFIX_LENGTH = 4;
+    private static final int RANDOM_STRING_LENGTH = 3;
+    private static final int RANDOM_NUMBER_LENGTH = 4;
+    private static final Random SECURE_RANDOM = new SecureRandom();
+
+    private SecretKeyGenerator() {
+        // 유틸리티 클래스는 인스턴스화 방지
+    }
+
+    /**
+     * 현장 관리자용 시크릿키 생성
+     *
+     * @param corpName 기업명
+     * @param siteId 현장 ID
+     * @return 생성된 시크릿키 (형식: {기업명앞4글자}-{siteId}-{randomString}-{randomNumber})
+     */
+    public static String generateManagerSecretKey(String corpName, Long siteId) {
+        return generateSecretKey(corpName, siteId);
+    }
+
+    /**
+     * 근로자용 시크릿키 생성
+     *
+     * @param corpName 기업명
+     * @param siteId 현장 ID
+     * @return 생성된 시크릿키 (형식: {기업명앞4글자}-{siteId}-{randomString}-{randomNumber})
+     */
+    public static String generateEmployeeSecretKey(String corpName, Long siteId) {
+        return generateSecretKey(corpName, siteId);
+    }
+
+    /**
+     * 시크릿키 생성 (내부 메서드)
+     *
+     * @param corpName 기업명
+     * @param siteId 현장 ID
+     * @return 생성된 시크릿키
+     */
+    private static String generateSecretKey(String corpName, Long siteId) {
+        String prefix = extractPrefix(corpName);
+        String randomString = generateRandomString();
+        String randomNumber = generateRandomNumber();
+        return String.format("%s-%d-%s-%s", prefix, siteId, randomString, randomNumber);
+    }
+
+    /**
+     * 기업명에서 Prefix 추출 (영문자 앞 4글자 대문자)
+     *
+     * @param corpName 기업명
+     * @return 추출된 Prefix (최대 4글자, 기본값: "SITE")
+     */
+    private static String extractPrefix(String corpName) {
+        if (corpName == null || corpName.isEmpty()) {
+            return DEFAULT_PREFIX;
+        }
+
+        // 영문자만 추출
+        StringBuilder alphaOnly = new StringBuilder();
+        for (char c : corpName.toCharArray()) {
+            if (Character.isAlphabetic(c) && c < 128) { // ASCII 영문자만
+                alphaOnly.append(c);
+            }
+        }
+
+        String extracted = alphaOnly.toString().toUpperCase();
+
+        // 추출된 영문자가 없으면 기본값 사용
+        if (extracted.isEmpty()) {
+            return DEFAULT_PREFIX;
+        }
+
+        // 4글자 이상이면 앞 4글자만, 미만이면 있는 만큼 사용
+        return extracted.length() >= PREFIX_LENGTH
+            ? extracted.substring(0, PREFIX_LENGTH)
+            : extracted;
+    }
+
+    /**
+     * 랜덤 문자열 생성 (대문자 알파벳 3자리)
+     *
+     * @return 랜덤 문자열 (예: "XYZ")
+     */
+    private static String generateRandomString() {
+        StringBuilder sb = new StringBuilder(RANDOM_STRING_LENGTH);
+        for (int i = 0; i < RANDOM_STRING_LENGTH; i++) {
+            int index = SECURE_RANDOM.nextInt(ALPHABET.length());
+            sb.append(ALPHABET.charAt(index));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 랜덤 숫자 생성 (4자리)
+     *
+     * @return 랜덤 숫자 문자열 (예: "9205")
+     */
+    private static String generateRandomNumber() {
+        int number = SECURE_RANDOM.nextInt(10000); // 0 ~ 9999
+        return String.format("%04d", number); // 4자리로 패딩 (예: 0001, 0123, 9999)
+    }
+}

--- a/src/main/java/com/concrete/buildup/global/util/SecretKeyGenerator.java
+++ b/src/main/java/com/concrete/buildup/global/util/SecretKeyGenerator.java
@@ -51,8 +51,13 @@ public class SecretKeyGenerator {
      * @param corpName 기업명
      * @param siteId 현장 ID
      * @return 생성된 시크릿키
+     * @throws IllegalArgumentException siteId가 null인 경우
      */
     private static String generateSecretKey(String corpName, Long siteId) {
+        if (siteId == null) {
+            throw new IllegalArgumentException("siteId must not be null");
+        }
+
         String prefix = extractPrefix(corpName);
         String randomString = generateRandomString();
         String randomNumber = generateRandomNumber();

--- a/src/test/java/com/concrete/buildup/domain/auth/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/concrete/buildup/domain/auth/integration/AuthIntegrationTest.java
@@ -102,21 +102,21 @@ class AuthIntegrationTest {
     @BeforeEach
     void setUp() {
         // 역할 데이터 준비
-        employeeRole = roleRepository.findByRoleName("EMPLOYEE")
+        employeeRole = roleRepository.findByRoleName("ROLE_EMPLOYEE")
                 .orElseGet(() -> roleRepository.save(Role.builder()
-                        .roleName("EMPLOYEE")
+                        .roleName("ROLE_EMPLOYEE")
                         .description("근로자 역할")
                         .build()));
 
-        managerRole = roleRepository.findByRoleName("MANAGER")
+        managerRole = roleRepository.findByRoleName("ROLE_MANAGER")
                 .orElseGet(() -> roleRepository.save(Role.builder()
-                        .roleName("MANAGER")
+                        .roleName("ROLE_MANAGER")
                         .description("현장 관리자 역할")
                         .build()));
 
-        corporationRole = roleRepository.findByRoleName("CORPORATION")
+        corporationRole = roleRepository.findByRoleName("ROLE_CORPORATION")
                 .orElseGet(() -> roleRepository.save(Role.builder()
-                        .roleName("CORPORATION")
+                        .roleName("ROLE_CORPORATION")
                         .description("기업 역할")
                         .build()));
 

--- a/src/test/java/com/concrete/buildup/domain/site/service/SecretKeyServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/site/service/SecretKeyServiceTest.java
@@ -1,0 +1,135 @@
+package com.concrete.buildup.domain.site.service;
+
+import com.concrete.buildup.domain.site.repository.SiteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * SecretKeyService 단위 테스트
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SecretKeyService 테스트")
+class SecretKeyServiceTest {
+
+    @Mock
+    private SiteRepository siteRepository;
+
+    @InjectMocks
+    private SecretKeyService secretKeyService;
+
+    @Test
+    @DisplayName("유니크한 시크릿키 생성 성공 - 중복 없음")
+    void generateUniqueSecretKeys_Success_NoDuplication() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = 1L;
+        given(siteRepository.existsByManagerSecretKey(anyString())).willReturn(false);
+        given(siteRepository.existsByEmployeeSecretKey(anyString())).willReturn(false);
+
+        // when
+        SecretKeyService.SecretKeyPair result = secretKeyService.generateUniqueSecretKeys(corpName, siteId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getManagerSecretKey()).isNotNull();
+        assertThat(result.getEmployeeSecretKey()).isNotNull();
+        assertThat(result.getManagerSecretKey()).matches("^[A-Z]{4}-\\d+-[A-Z]{3}-\\d{4}$");
+        assertThat(result.getEmployeeSecretKey()).matches("^[A-Z]{4}-\\d+-[A-Z]{3}-\\d{4}$");
+        assertThat(result.getManagerSecretKey()).isNotEqualTo(result.getEmployeeSecretKey());
+
+        verify(siteRepository, times(1)).existsByManagerSecretKey(anyString());
+        verify(siteRepository, times(1)).existsByEmployeeSecretKey(anyString());
+    }
+
+    @Test
+    @DisplayName("유니크한 시크릿키 생성 성공 - 첫 시도에서 중복, 재시도 성공")
+    void generateUniqueSecretKeys_Success_AfterRetry() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = 1L;
+
+        // 첫 번째 시도는 중복, 두 번째 시도는 성공
+        given(siteRepository.existsByManagerSecretKey(anyString()))
+                .willReturn(true)   // 첫 번째 시도: 중복
+                .willReturn(false); // 두 번째 시도: 성공
+        given(siteRepository.existsByEmployeeSecretKey(anyString()))
+                .willReturn(false);
+
+        // when
+        SecretKeyService.SecretKeyPair result = secretKeyService.generateUniqueSecretKeys(corpName, siteId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getManagerSecretKey()).isNotNull();
+        assertThat(result.getEmployeeSecretKey()).isNotNull();
+
+        verify(siteRepository, times(2)).existsByManagerSecretKey(anyString());
+        verify(siteRepository, times(2)).existsByEmployeeSecretKey(anyString());
+    }
+
+    @Test
+    @DisplayName("유니크한 시크릿키 생성 실패 - 최대 재시도 횟수 초과")
+    void generateUniqueSecretKeys_Fail_MaxRetryExceeded() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = 1L;
+
+        // 항상 중복으로 반환
+        given(siteRepository.existsByManagerSecretKey(anyString())).willReturn(true);
+        given(siteRepository.existsByEmployeeSecretKey(anyString())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> secretKeyService.generateUniqueSecretKeys(corpName, siteId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("유니크한 시크릿키 생성에 실패했습니다");
+
+        verify(siteRepository, times(10)).existsByManagerSecretKey(anyString());
+        verify(siteRepository, times(10)).existsByEmployeeSecretKey(anyString());
+    }
+
+    @Test
+    @DisplayName("SecretKeyPair 생성 검증")
+    void secretKeyPair_ShouldHaveCorrectValues() {
+        // given
+        String managerKey = "CONC-1-ABC-1234";
+        String employeeKey = "CONC-1-XYZ-5678";
+
+        // when
+        SecretKeyService.SecretKeyPair pair = new SecretKeyService.SecretKeyPair(managerKey, employeeKey);
+
+        // then
+        assertThat(pair.getManagerSecretKey()).isEqualTo(managerKey);
+        assertThat(pair.getEmployeeSecretKey()).isEqualTo(employeeKey);
+    }
+
+    @Test
+    @DisplayName("시크릿키 포맷 검증 - 기업명 prefix 포함")
+    void secretKey_ShouldContainCorpNamePrefix() {
+        // given
+        String corpName = "BUILD UP";
+        Long siteId = 5L;
+        given(siteRepository.existsByManagerSecretKey(anyString())).willReturn(false);
+        given(siteRepository.existsByEmployeeSecretKey(anyString())).willReturn(false);
+
+        // when
+        SecretKeyService.SecretKeyPair result = secretKeyService.generateUniqueSecretKeys(corpName, siteId);
+
+        // then
+        assertThat(result.getManagerSecretKey()).startsWith("BUIL-5-");
+        assertThat(result.getEmployeeSecretKey()).startsWith("BUIL-5-");
+    }
+}

--- a/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
@@ -1,0 +1,212 @@
+package com.concrete.buildup.domain.site.service;
+
+import com.concrete.buildup.domain.auth.entity.Corporation;
+import com.concrete.buildup.domain.auth.entity.User;
+import com.concrete.buildup.domain.auth.repository.CorporationRepository;
+import com.concrete.buildup.domain.auth.repository.UserRepository;
+import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
+import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
+import com.concrete.buildup.domain.site.entity.Site;
+import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.global.exception.BusinessException;
+import com.concrete.buildup.global.exception.errorcode.AuthErrorCode;
+import com.concrete.buildup.global.exception.errorcode.SiteErrorCode;
+import com.concrete.buildup.global.util.SecurityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * SiteService 단위 테스트
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SiteService 테스트")
+class SiteServiceTest {
+
+    @Mock
+    private SiteRepository siteRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CorporationRepository corporationRepository;
+
+    @Mock
+    private SecretKeyService secretKeyService;
+
+    @InjectMocks
+    private SiteService siteService;
+
+    /**
+     * BaseEntity의 id 필드를 Reflection으로 설정하는 헬퍼 메서드
+     */
+    private void setId(Object entity, Long id) throws Exception {
+        var idField = entity.getClass().getSuperclass().getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(entity, id);
+    }
+
+    @Test
+    @DisplayName("현장 등록 성공")
+    void createSite_Success() throws Exception {
+        // given
+        String userId = "testuser";
+        User mockUser = User.builder().userId(userId).build();
+        setId(mockUser, 1L);
+
+        Corporation mockCorporation = Corporation.builder()
+                .corpName("CONCRETE")
+                .build();
+        setId(mockCorporation, 1L);
+
+        SiteCreateRequest request = SiteCreateRequest.builder()
+                .siteName("강남 재개발 현장")
+                .siteAddress("서울시 강남구")
+                .clientName("서울시청")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .endDate(LocalDate.of(2025, 12, 31))
+                .build();
+
+        Site savedSite = Site.builder()
+                .siteName(request.getSiteName())
+                .siteAddress(request.getSiteAddress())
+                .clientName(request.getClientName())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .corporation(mockCorporation)
+                .managerSecretKey("CONC-1-ABC-1234")
+                .employeeSecretKey("CONC-1-XYZ-5678")
+                .build();
+        setId(savedSite, 1L);
+
+        SecretKeyService.SecretKeyPair mockKeyPair = new SecretKeyService.SecretKeyPair(
+                "CONC-1-ABC-1234",
+                "CONC-1-XYZ-5678"
+        );
+
+        try (MockedStatic<SecurityUtil> securityUtil = mockStatic(SecurityUtil.class)) {
+            securityUtil.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+            given(userRepository.findByUserId(userId)).willReturn(Optional.of(mockUser));
+            given(corporationRepository.findByUserId(1L)).willReturn(Optional.of(mockCorporation));
+            given(siteRepository.save(any(Site.class))).willReturn(savedSite);
+            given(secretKeyService.generateUniqueSecretKeys(anyString(), anyLong())).willReturn(mockKeyPair);
+
+            // when
+            SiteCreateResponse response = siteService.createSite(request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getSiteId()).isEqualTo(1L);
+            assertThat(response.getSiteName()).isEqualTo("강남 재개발 현장");
+            assertThat(response.getManagerSecretKey()).isEqualTo("CONC-1-ABC-1234");
+            assertThat(response.getEmployeeSecretKey()).isEqualTo("CONC-1-XYZ-5678");
+
+            verify(userRepository, times(1)).findByUserId(userId);
+            verify(corporationRepository, times(1)).findByUserId(1L);
+            verify(siteRepository, times(1)).save(any(Site.class));
+            verify(secretKeyService, times(1)).generateUniqueSecretKeys("CONCRETE", 1L);
+        }
+    }
+
+    @Test
+    @DisplayName("현장 등록 실패 - 사용자 없음")
+    void createSite_Fail_UserNotFound() {
+        // given
+        String userId = "nonexistentuser";
+        SiteCreateRequest request = SiteCreateRequest.builder()
+                .siteName("테스트 현장")
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtil = mockStatic(SecurityUtil.class)) {
+            securityUtil.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+            given(userRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> siteService.createSite(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.USER_NOT_FOUND);
+
+            verify(userRepository, times(1)).findByUserId(userId);
+            verify(corporationRepository, never()).findByUserId(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("현장 등록 실패 - 기업 정보 없음")
+    void createSite_Fail_CorporationNotFound() throws Exception {
+        // given
+        String userId = "testuser";
+        User mockUser = User.builder().userId(userId).build();
+        setId(mockUser, 1L);
+
+        SiteCreateRequest request = SiteCreateRequest.builder()
+                .siteName("테스트 현장")
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtil = mockStatic(SecurityUtil.class)) {
+            securityUtil.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+            given(userRepository.findByUserId(userId)).willReturn(Optional.of(mockUser));
+            given(corporationRepository.findByUserId(1L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> siteService.createSite(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", SiteErrorCode.CORPORATION_NOT_FOUND);
+
+            verify(userRepository, times(1)).findByUserId(userId);
+            verify(corporationRepository, times(1)).findByUserId(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("현장 등록 실패 - 잘못된 날짜 범위 (종료일이 시작일보다 이전)")
+    void createSite_Fail_InvalidDateRange() throws Exception {
+        // given
+        String userId = "testuser";
+        User mockUser = User.builder().userId(userId).build();
+        setId(mockUser, 1L);
+
+        Corporation mockCorporation = Corporation.builder()
+                .corpName("CONCRETE")
+                .build();
+        setId(mockCorporation, 1L);
+
+        SiteCreateRequest request = SiteCreateRequest.builder()
+                .siteName("테스트 현장")
+                .startDate(LocalDate.of(2025, 12, 31))
+                .endDate(LocalDate.of(2025, 1, 1))  // 종료일이 시작일보다 이전
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtil = mockStatic(SecurityUtil.class)) {
+            securityUtil.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+            given(userRepository.findByUserId(userId)).willReturn(Optional.of(mockUser));
+            given(corporationRepository.findByUserId(1L)).willReturn(Optional.of(mockCorporation));
+
+            // when & then
+            assertThatThrownBy(() -> siteService.createSite(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", SiteErrorCode.INVALID_DATE_RANGE);
+
+            verify(siteRepository, never()).save(any(Site.class));
+        }
+    }
+}

--- a/src/test/java/com/concrete/buildup/global/util/SecretKeyGeneratorTest.java
+++ b/src/test/java/com/concrete/buildup/global/util/SecretKeyGeneratorTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * SecretKeyGenerator 단위 테스트
@@ -100,5 +101,31 @@ class SecretKeyGeneratorTest {
         // then
         assertThat(pattern.matcher(managerKey).matches()).isTrue();
         assertThat(pattern.matcher(employeeKey).matches()).isTrue();
+    }
+
+    @Test
+    @DisplayName("관리자 시크릿키 생성 - siteId가 null이면 IllegalArgumentException 발생")
+    void generateManagerSecretKey_WithNullSiteId_ShouldThrowException() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = null;
+
+        // when & then
+        assertThatThrownBy(() -> SecretKeyGenerator.generateManagerSecretKey(corpName, siteId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("siteId must not be null");
+    }
+
+    @Test
+    @DisplayName("근로자 시크릿키 생성 - siteId가 null이면 IllegalArgumentException 발생")
+    void generateEmployeeSecretKey_WithNullSiteId_ShouldThrowException() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = null;
+
+        // when & then
+        assertThatThrownBy(() -> SecretKeyGenerator.generateEmployeeSecretKey(corpName, siteId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("siteId must not be null");
     }
 }

--- a/src/test/java/com/concrete/buildup/global/util/SecretKeyGeneratorTest.java
+++ b/src/test/java/com/concrete/buildup/global/util/SecretKeyGeneratorTest.java
@@ -1,0 +1,104 @@
+package com.concrete.buildup.global.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SecretKeyGenerator 단위 테스트
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@DisplayName("SecretKeyGenerator 테스트")
+class SecretKeyGeneratorTest {
+
+    @Test
+    @DisplayName("관리자 시크릿키 생성 - 정상 포맷 검증")
+    void generateManagerSecretKey_ShouldReturnValidFormat() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = 1L;
+
+        // when
+        String secretKey = SecretKeyGenerator.generateManagerSecretKey(corpName, siteId);
+
+        // then
+        assertThat(secretKey).isNotNull();
+        assertThat(secretKey).matches("^[A-Z]{4}-\\d+-[A-Z]{3}-\\d{4}$");
+        assertThat(secretKey).startsWith("CONC-1-");
+    }
+
+    @Test
+    @DisplayName("근로자 시크릿키 생성 - 정상 포맷 검증")
+    void generateEmployeeSecretKey_ShouldReturnValidFormat() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = 1L;
+
+        // when
+        String secretKey = SecretKeyGenerator.generateEmployeeSecretKey(corpName, siteId);
+
+        // then
+        assertThat(secretKey).isNotNull();
+        assertThat(secretKey).matches("^[A-Z]{4}-\\d+-[A-Z]{3}-\\d{4}$");
+        assertThat(secretKey).startsWith("CONC-1-");
+    }
+
+    @Test
+    @DisplayName("기업명 prefix 검증 - 생성된 시크릿키에 기업명 포함 확인")
+    void secretKey_ShouldContainCorpNamePrefix() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = 1L;
+
+        // when
+        String secretKey = SecretKeyGenerator.generateManagerSecretKey(corpName, siteId);
+
+        // then
+        assertThat(secretKey).startsWith("CONC-1-");
+    }
+
+    @Test
+    @DisplayName("시크릿키 유니크성 검증 - 여러번 생성 시 모두 다른 값")
+    void generateSecretKey_ShouldBeUnique() {
+        // given
+        String corpName = "CONCRETE";
+        Long siteId = 1L;
+        Set<String> generatedKeys = new HashSet<>();
+        int generateCount = 100;
+
+        // when
+        for (int i = 0; i < generateCount; i++) {
+            String managerKey = SecretKeyGenerator.generateManagerSecretKey(corpName, siteId);
+            String employeeKey = SecretKeyGenerator.generateEmployeeSecretKey(corpName, siteId);
+            generatedKeys.add(managerKey);
+            generatedKeys.add(employeeKey);
+        }
+
+        // then
+        assertThat(generatedKeys).hasSize(generateCount * 2);
+    }
+
+    @Test
+    @DisplayName("시크릿키 포맷 - prefix-siteId-random-number 형식")
+    void secretKeyFormat_ShouldFollowPattern() {
+        // given
+        String corpName = "TEST COMPANY";
+        Long siteId = 999L;
+        Pattern pattern = Pattern.compile("^[A-Z]{4}-999-[A-Z]{3}-\\d{4}$");
+
+        // when
+        String managerKey = SecretKeyGenerator.generateManagerSecretKey(corpName, siteId);
+        String employeeKey = SecretKeyGenerator.generateEmployeeSecretKey(corpName, siteId);
+
+        // then
+        assertThat(pattern.matcher(managerKey).matches()).isTrue();
+        assertThat(pattern.matcher(employeeKey).matches()).isTrue();
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-154](https://concrete-buildup.atlassian.net/browse/BU-154)

## 📝 변경 사항 요약

### 주요 변경사항
- 현장 등록 시스템 전체 레이어 구현 (Entity, Repository, Service, Controller, DTO)
- 시크릿키 생성 유틸리티 및 중복 검증 서비스 구현
- 현장 등록 API 핵심 기능 단위 테스트 작성 (14개 테스트)
- manager_id nullable 스키마 수정 및 ERD 문서화

## 🎯 변경 목적
기업 관리자가 신규 건설 현장을 등록하고, 현장 관리자 및 근로자가 사용할 수 있는 유니크한 시크릿키를 자동 생성하는 시스템을 구현합니다.

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] Story 1: Site 엔티티 확장 - 현장 정보 및 시크릿키 관리 컬럼 추가
- [x] Story 2: 시크릿키 생성 유틸리티 - SecretKeyGenerator, SecretKeyService 구현
- [x] Story 3: 현장 등록 API - SiteService, SiteController, DTO 구현
- [x] Story 4: 예외 처리 - SiteErrorCode, GlobalExceptionHandler에 IllegalStateException 핸들러 추가
- [x] Story 5: 단위 테스트 및 Swagger UI 테스트 - 14개 단위 테스트, Swagger UI 검증 완료

### 버그 수정 (Bug Fixes)
- [x] Site 엔티티 manager_id nullable 명시화 - 현장 등록 시점에는 관리자 미할당 상태 지원
- [x] 데이터베이스 스키마 NOT NULL 제약조건 오류 수정

### 기타 변경사항 (Others)
- [x] ERD 문서 업데이트 - sites 테이블 스키마 확장 및 변경 이력 추가

## 🧪 테스트 방법

### 단위 테스트
- [x] 단위 테스트 작성 완료 (14개 테스트)
- [x] 기존 테스트 통과 확인
- 테스트 커버리지: 핵심 기능 100%

**테스트 파일:**
1. `SecretKeyGeneratorTest.java` - 시크릿키 생성 유틸리티 테스트 (5개)
2. `SecretKeyServiceTest.java` - 시크릿키 중복 검증 및 재시도 로직 테스트 (5개)
3. `SiteServiceTest.java` - 현장 등록 비즈니스 로직 테스트 (4개)

### 수동 테스트
1. Swagger UI 접속: http://localhost:8080/api/swagger-ui/index.html
2. POST /api/v1/auth/login으로 기업 관리자 로그인 (CORPORATION 역할)
3. Authorize 버튼 클릭하여 JWT 토큰 설정
4. POST /api/v1/sites로 현장 등록 요청

### API 테스트 예시
```bash
# 1. 로그인
curl -X POST http://localhost:8080/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"userId": "testcorp001", "password": "Test123@@"}'

# 2. 현장 등록
curl -X POST http://localhost:8080/api/v1/sites \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer {ACCESS_TOKEN}" \
  -d '{
    "siteName": "강남 재개발 현장",
    "siteAddress": "서울시 강남구",
    "clientName": "서울시청",
    "startDate": "2025-01-01",
    "endDate": "2025-12-31"
  }'
```

**예상 결과:**
```json
{
  "success": true,
  "message": "현장이 성공적으로 등록되었습니다",
  "data": {
    "siteId": 175,
    "siteName": "강남 재개발 현장",
    "siteAddress": "서울시 강남구",
    "clientName": "서울시청",
    "startDate": "2025-01-01",
    "endDate": "2025-12-31",
    "managerSecretKey": "CONC-175-QWK-3914",
    "employeeSecretKey": "CONC-175-GOR-1398"
  }
}
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 있음 (수동 마이그레이션 필요)

**마이그레이션 상세:**
- 변경 테이블: `sites`
- 변경 내용: 
  - `client_name` VARCHAR(100) NULL 컬럼 추가
  - `start_date` DATE NULL 컬럼 추가
  - `end_date` DATE NULL 컬럼 추가
  - `manager_id` BIGINT NOT NULL → NULL로 변경 (ALTER TABLE)
  - `manager_secret_key` VARCHAR(100) UNIQUE NULL 컬럼 추가
  - `employee_secret_key` VARCHAR(100) UNIQUE NULL 컬럼 추가
  - `secret_key_expires_at` DATETIME NULL 컬럼 추가

**수동 마이그레이션 SQL:**
```sql
ALTER TABLE sites MODIFY COLUMN manager_id BIGINT NULL;
```

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거 (환경변수 또는 설정 파일 사용)
- [x] 로그 레벨 적절히 설정 (DEBUG → INFO/WARN/ERROR)

### 테스트
- [x] 단위 테스트 작성 완료
- [x] 통합 테스트 작성 완료 (Swagger UI 수동 테스트)
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토 - JPA 사용으로 안전
- [x] XSS 취약점 검토 - JSON 응답으로 안전
- [x] 인증/인가 로직 검토 - CORPORATION 역할 체크
- [x] 민감 정보 노출 검토 - 시크릿키는 응답에만 포함, DB에 암호화 없이 저장 (용도 특성상 공유 필요)
- [x] 입력 검증 로직 추가 - DTO validation 적용

### 성능
- [x] N+1 쿼리 문제 검토 - LAZY 로딩 사용
- [x] 불필요한 DB 쿼리 최적화 - 필요한 조회만 수행
- [x] 적절한 인덱스 사용 확인 - UNIQUE INDEX (manager_secret_key, employee_secret_key)
- [x] 대용량 데이터 처리 고려 - 단일 현장 등록이므로 문제없음

### 문서
- [x] API 문서 업데이트 (Swagger 주석)
- [x] README.md 업데이트 (필요 없음)
- [x] 코드 주석 작성 (복잡한 로직만)
- [x] Jira Story 상태 업데이트 (Story 1-5 완료)

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: BU-154`)
- [x] develop 브랜치 최신 코드 반영 (rebase)
- [x] 충돌 해결 완료

## 📌 리뷰어에게
- 시크릿키 생성 로직의 재시도 메커니즘(최대 10회)이 적절한지 검토 부탁드립니다.
- manager_id를 nullable로 변경한 부분이 비즈니스 로직상 타당한지 확인 부탁드립니다.
- 단위 테스트에서 Reflection을 사용해 BaseEntity의 id를 설정하는 방식이 괜찮은지 의견 부탁드립니다.

## 🔗 관련 PR/Issue
- Related Story: BU-154 (현장 등록 시스템 구현)

---

## 📚 참고 자료
- [프로젝트 ERD](.claude/ERD.md)
- [프로젝트 컨벤션](.claude/CLAUDE.md)

[BU-154]: https://build-up-project.atlassian.net/browse/BU-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 현장 등록 API 추가 (POST /v1/sites) — 생성 시 매니저/직원용 보안키 반환(마스킹 적용)
  * 고유 보안키 자동생성 및 재시도 처리

* **개선사항**
  * sites에 고객명(client_name), 공사 시작/종료일 필드 추가 및 기간 유효성 검사
  * 매니저 할당을 선택사항(nullable)으로 변경
  * 권한 문자열을 ROLE_* 형식으로 통일

* **오류/응답**
  * 보안키 생성 실패 및 관련 예외에 대해 일관된 500 응답 처리 추가

* **테스트/문서**
  * 보안키 생성과 현장 등록 흐름에 대한 단위·통합 테스트 및 변경 로그 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->