### PR TITLE
Feature/bu 155: 상용직 급여 내역 조회 API 구현

### DIFF
--- a/.claude/ERD.md
+++ b/.claude/ERD.md
@@ -480,6 +480,7 @@ Build-Up Platform 데이터베이스 구조 설계 문서입니다.
 | `employee_id` | BIGINT | FK, NOT NULL | 근로자 ID |
 | `contract_id` | BIGINT | FK, NOT NULL | 계약 ID |
 | `corporation_id` | BIGINT | FK, NOT NULL | 기업 ID |
+| `site_id` | BIGINT | FK, NOT NULL | 현장 ID |
 | `salary_year` | INT | NOT NULL | 급여 대상 연도 (예: 2025) |
 | `salary_month` | INT | NOT NULL | 급여 대상 월 (1~12) |
 | `salary_week` | INT | NULL | 급여 대상 주차 (주급인 경우, 1~5) |
@@ -504,19 +505,22 @@ Build-Up Platform 데이터베이스 구조 설계 문서입니다.
 
 **인덱스:**
 - PRIMARY KEY: `id`
-- INDEX: `employee_id`, `contract_id`, `corporation_id`
+- INDEX: `employee_id`, `contract_id`, `corporation_id`, `site_id`
 - INDEX: `search_date`
 - INDEX: `pay_status`
 - INDEX: `s3_key`
+- INDEX: `idx_period_search (site_id, salary_year, salary_month, emp_type, pay_cycle)` - 기간별 조회 최적화
 - UNIQUE INDEX: `(employee_id, salary_year, salary_month, pay_cycle, salary_week, salary_day)` - 중복 방지
 - FOREIGN KEY: `employee_id` REFERENCES `employees(id)`
 - FOREIGN KEY: `contract_id` REFERENCES `contracts(id)`
 - FOREIGN KEY: `corporation_id` REFERENCES `corporations(id)`
+- FOREIGN KEY: `site_id` REFERENCES `sites(id)`
 
 **관계:**
 - N:1 → employees
 - N:1 → contracts
 - N:1 → corporations
+- N:1 → sites
 - 1:N ← payslip_items
 
 ---
@@ -872,5 +876,6 @@ ON work_reports(work_report_status);
 | 2025-11-15 | payrolls 테이블 컬럼 추가 (salary_year, salary_month, salary_week, salary_day, s3_key, generated_at) 및 중복 방지 UNIQUE INDEX 추가 (급여명세서 자동 생성 기능) | 문현민 |
 | 2025-11-12 | users 테이블 phone 컬럼 제약조건 변경 (NOT NULL → NULL, 2단계 회원가입 지원) | 김세원 |
 | 2025-11-16 | attendances 테이블 is_late 컬럼 추가 (계약서 기반 지각 판단, 출근 시간 +5분 초과 시 true) | 김세원 |
+| 2025-11-17 | payrolls 테이블 site_id 컬럼 추가 및 기간별 조회 복합 인덱스 추가 (급여 내역 조회 API) | Claude |
 
 ---

--- a/src/main/java/com/concrete/buildup/domain/payroll/controller/PayrollController.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/controller/PayrollController.java
@@ -1,0 +1,83 @@
+package com.concrete.buildup.domain.payroll.controller;
+
+import com.concrete.buildup.domain.contract.enums.EmpType;
+import com.concrete.buildup.domain.payroll.dto.SalaryHistorySummaryResponse;
+import com.concrete.buildup.domain.payroll.service.PayrollService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 급여 내역 조회 컨트롤러
+ *
+ * <p>급여 내역 기간별 조회 API를 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Slf4j
+@Tag(name = "Payroll", description = "급여 내역 조회 API")
+@RestController
+@RequestMapping("/v1/payrolls")
+@RequiredArgsConstructor
+public class PayrollController {
+
+    private final PayrollService payrollService;
+
+    /**
+     * 상용직 기간별 급여 내역 조회
+     *
+     * <p>특정 현장의 상용직 근로자들에 대한 기간별 급여 내역을 조회합니다.</p>
+     *
+     * @param siteId 현장 ID (필수)
+     * @param year 급여 대상 연도 (예: 2025)
+     * @param month 급여 대상 월 (1~12)
+     * @param page 페이지 번호 (기본값: 1)
+     * @param size 페이지 크기 (기본값: 20)
+     * @return 급여 내역 요약 정보 (통계 + 목록)
+     */
+    @Operation(
+            summary = "상용직 기간별 급여 내역 조회",
+            description = "특정 현장의 상용직 근로자들에 대한 기간별 급여 내역을 조회합니다. " +
+                    "전체 통계(총 건수, 미지급 건수, 총 지급액)와 함께 페이징된 급여 목록을 반환합니다."
+    )
+    @GetMapping("/period/permanent")
+    public ResponseEntity<SalaryHistorySummaryResponse> getPermanentSalaryHistory(
+            @Parameter(description = "현장 ID", required = true, example = "1")
+            @RequestParam Long siteId,
+
+            @Parameter(description = "급여 대상 연도", required = true, example = "2025")
+            @RequestParam Integer year,
+
+            @Parameter(description = "급여 대상 월 (1~12)", required = true, example = "11")
+            @RequestParam Integer month,
+
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1")
+            @RequestParam(defaultValue = "1") Integer page,
+
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        log.info("상용직 급여 내역 조회 - siteId: {}, year: {}, month: {}, page: {}, size: {}",
+                siteId, year, month, page, size);
+
+        SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
+                siteId,
+                year,
+                month,
+                EmpType.PERMANENT,
+                null, // 상용직은 payCycle이 항상 MONTHLY이므로 null
+                PageRequest.of(page - 1, size)
+        );
+
+        log.info("상용직 급여 내역 조회 완료 - totalCount: {}, unpaidCount: {}",
+                response.getTotalCount(), response.getUnpaidCount());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/payroll/controller/PayrollController.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/controller/PayrollController.java
@@ -6,6 +6,8 @@ import com.concrete.buildup.domain.payroll.service.PayrollService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -53,19 +55,19 @@ public class PayrollController {
     @GetMapping("/period/permanent")
     public ResponseEntity<SalaryHistorySummaryResponse> getPermanentSalaryHistory(
             @Parameter(description = "현장 ID", required = true, example = "1")
-            @RequestParam Long siteId,
+            @RequestParam @Min(1) Long siteId,
 
             @Parameter(description = "급여 대상 연도", required = true, example = "2025")
-            @RequestParam Integer year,
+            @RequestParam @Min(2000) @Max(2100) Integer year,
 
             @Parameter(description = "급여 대상 월 (1~12)", required = true, example = "11")
-            @RequestParam Integer month,
+            @RequestParam @Min(1) @Max(12) Integer month,
 
             @Parameter(description = "페이지 번호 (1부터 시작)", example = "1")
-            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "1") @Min(1) Integer page,
 
             @Parameter(description = "페이지 크기", example = "20")
-            @RequestParam(defaultValue = "20") Integer size
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) Integer size
     ) {
         log.info("상용직 급여 내역 조회 - siteId: {}, year: {}, month: {}, page: {}, size: {}",
                 siteId, year, month, page, size);

--- a/src/main/java/com/concrete/buildup/domain/payroll/controller/PayrollController.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/controller/PayrollController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -25,6 +27,8 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/v1/payrolls")
 @RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('MANAGER', 'CORPORATION')")
+@Validated
 public class PayrollController {
 
     private final PayrollService payrollService;

--- a/src/main/java/com/concrete/buildup/domain/payroll/dto/SalaryHistoryItemResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/dto/SalaryHistoryItemResponse.java
@@ -1,0 +1,79 @@
+package com.concrete.buildup.domain.payroll.dto;
+
+import com.concrete.buildup.domain.contract.enums.PayPeriod;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/**
+ * 급여 내역 조회 - 개별 항목 응답 DTO
+ *
+ * <p>급여 내역 목록의 각 항목을 나타냅니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+public class SalaryHistoryItemResponse {
+
+    /**
+     * 사원 ID
+     */
+    private Long employeeId;
+
+    /**
+     * 사원 이름
+     */
+    private String name;
+
+    /**
+     * 주민등록번호 (마스킹 처리)
+     * 예: 920315-2******
+     */
+    private String residentId;
+
+    /**
+     * 지급일
+     * 예: 25.09.12
+     */
+    private String payDate;
+
+    /**
+     * 총 지급액
+     */
+    private BigDecimal totalPay;
+
+    /**
+     * 비과세 소득
+     */
+    private BigDecimal nonTaxIncome;
+
+    /**
+     * 소득세
+     */
+    private BigDecimal taxIncome;
+
+    /**
+     * 주민세
+     */
+    private BigDecimal localTax;
+
+    /**
+     * 지급 완료 여부
+     */
+    private Boolean paid;
+
+    /**
+     * 급여명세서 PDF 존재 여부
+     */
+    private Boolean payslipAvailable;
+
+    /**
+     * 급여 주기
+     * 상용직: MONTHLY (고정)
+     * 일용직: MONTHLY/WEEKLY/DAILY
+     */
+    private PayPeriod payCycle;
+}

--- a/src/main/java/com/concrete/buildup/domain/payroll/dto/SalaryHistorySummaryResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/dto/SalaryHistorySummaryResponse.java
@@ -1,0 +1,40 @@
+package com.concrete.buildup.domain.payroll.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 급여 내역 조회 - 요약 정보 응답 DTO
+ *
+ * <p>급여 내역 목록과 함께 전체 통계 정보를 포함합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+public class SalaryHistorySummaryResponse {
+
+    /**
+     * 전체 급여 내역 건수
+     */
+    private Integer totalCount;
+
+    /**
+     * 미지급 건수
+     */
+    private Integer unpaidCount;
+
+    /**
+     * 총 지급액 (지급 완료된 금액의 합계)
+     */
+    private BigDecimal totalPaidAmount;
+
+    /**
+     * 급여 내역 목록
+     */
+    private List<SalaryHistoryItemResponse> data;
+}

--- a/src/main/java/com/concrete/buildup/domain/payroll/entity/Payroll.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/entity/Payroll.java
@@ -36,9 +36,11 @@ import java.time.LocalDateTime;
         @Index(name = "idx_employee_id", columnList = "employee_id"),
         @Index(name = "idx_contract_id", columnList = "contract_id"),
         @Index(name = "idx_corporation_id", columnList = "corporation_id"),
+        @Index(name = "idx_site_id", columnList = "site_id"),
         @Index(name = "idx_search_date", columnList = "search_date"),
         @Index(name = "idx_pay_status", columnList = "pay_status"),
-        @Index(name = "idx_s3_key", columnList = "s3_key")
+        @Index(name = "idx_s3_key", columnList = "s3_key"),
+        @Index(name = "idx_period_search", columnList = "site_id, salary_year, salary_month, emp_type, pay_cycle")
 }, uniqueConstraints = {
         @UniqueConstraint(
                 name = "idx_payroll_unique",
@@ -69,6 +71,13 @@ public class Payroll extends BaseEntity {
      */
     @Column(name = "corporation_id", nullable = false)
     private Long corporationId;
+
+    /**
+     * 현장 ID
+     * TODO: Site 엔티티 구현 후 @ManyToOne 연관관계로 변경
+     */
+    @Column(name = "site_id", nullable = false)
+    private Long siteId;
 
     // ========== 급여 대상 기간 ==========
 
@@ -211,7 +220,7 @@ public class Payroll extends BaseEntity {
     // ========== 빌더 ==========
 
     @Builder
-    public Payroll(Long employeeId, Long contractId, Long corporationId,
+    public Payroll(Long employeeId, Long contractId, Long corporationId, Long siteId,
                    Integer salaryYear, Integer salaryMonth, Integer salaryWeek, LocalDate salaryDay,
                    LocalDate searchDate, LocalDate payDueDate,
                    EmpType empType, String empName, String residentNum,
@@ -222,6 +231,7 @@ public class Payroll extends BaseEntity {
         this.employeeId = employeeId;
         this.contractId = contractId;
         this.corporationId = corporationId;
+        this.siteId = siteId;
         this.salaryYear = salaryYear;
         this.salaryMonth = salaryMonth;
         this.salaryWeek = salaryWeek;

--- a/src/main/java/com/concrete/buildup/domain/payroll/repository/PayrollRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/repository/PayrollRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -113,5 +114,59 @@ public interface PayrollRepository extends JpaRepository<Payroll, Long> {
             @Param("empType") EmpType empType,
             @Param("payCycle") @Nullable PayPeriod payCycle,
             Pageable pageable
+    );
+
+    /**
+     * 현장별 기간별 미지급 건수 조회 (전체 기준)
+     *
+     * <p>페이징과 무관하게 전체 데이터셋에서 미지급 건수를 계산합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param year 급여 대상 연도
+     * @param month 급여 대상 월
+     * @param empType 근로자 유형
+     * @param payCycle 급여 주기 (nullable)
+     * @return 미지급 건수
+     */
+    @Query("SELECT COUNT(p) FROM Payroll p " +
+            "WHERE p.siteId = :siteId " +
+            "AND p.salaryYear = :year " +
+            "AND p.salaryMonth = :month " +
+            "AND p.empType = :empType " +
+            "AND (:payCycle IS NULL OR p.payCycle = :payCycle) " +
+            "AND p.payStatus != com.concrete.buildup.domain.payroll.enums.PayStatus.PAID")
+    long countUnpaidBySiteAndPeriodAndType(
+            @Param("siteId") Long siteId,
+            @Param("year") Integer year,
+            @Param("month") Integer month,
+            @Param("empType") EmpType empType,
+            @Param("payCycle") @Nullable PayPeriod payCycle
+    );
+
+    /**
+     * 현장별 기간별 총 지급액 조회 (전체 기준)
+     *
+     * <p>페이징과 무관하게 전체 데이터셋에서 지급 완료된 급여의 총액을 계산합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param year 급여 대상 연도
+     * @param month 급여 대상 월
+     * @param empType 근로자 유형
+     * @param payCycle 급여 주기 (nullable)
+     * @return 총 지급액 (지급 완료 건만 합산)
+     */
+    @Query("SELECT COALESCE(SUM(p.totalPay), 0) FROM Payroll p " +
+            "WHERE p.siteId = :siteId " +
+            "AND p.salaryYear = :year " +
+            "AND p.salaryMonth = :month " +
+            "AND p.empType = :empType " +
+            "AND (:payCycle IS NULL OR p.payCycle = :payCycle) " +
+            "AND p.payStatus = com.concrete.buildup.domain.payroll.enums.PayStatus.PAID")
+    BigDecimal sumTotalPaidAmountBySiteAndPeriodAndType(
+            @Param("siteId") Long siteId,
+            @Param("year") Integer year,
+            @Param("month") Integer month,
+            @Param("empType") EmpType empType,
+            @Param("payCycle") @Nullable PayPeriod payCycle
     );
 }

--- a/src/main/java/com/concrete/buildup/domain/payroll/repository/PayrollRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/repository/PayrollRepository.java
@@ -1,11 +1,15 @@
 package com.concrete.buildup.domain.payroll.repository;
 
+import com.concrete.buildup.domain.contract.enums.EmpType;
 import com.concrete.buildup.domain.contract.enums.PayPeriod;
 import com.concrete.buildup.domain.payroll.entity.Payroll;
 import com.concrete.buildup.domain.payroll.enums.PayStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -69,5 +73,45 @@ public interface PayrollRepository extends JpaRepository<Payroll, Long> {
      */
     List<Payroll> findByEmployeeIdAndSalaryYearAndSalaryMonth(
             Long employeeId, Integer year, Integer month
+    );
+
+    /**
+     * 현장별 기간별 급여 조회 (상용직/일용직 공통)
+     *
+     * <p>급여 내역 조회 API에서 사용됩니다.</p>
+     *
+     * 파라미터:
+     * - siteId: 현장 ID
+     * - year: 급여 대상 연도
+     * - month: 급여 대상 월
+     * - empType: 근로자 유형 (PERMANENT: 상용직, DAILY: 일용직)
+     * - payCycle: 급여 주기 (상용직: MONTHLY, 일용직: MONTHLY/WEEKLY/DAILY, nullable)
+     * - pageable: 페이징 정보
+     *
+     * 인덱스 활용:
+     * - idx_period_search (site_id, salary_year, salary_month, emp_type, pay_cycle)
+     *
+     * @param siteId 현장 ID
+     * @param year 급여 대상 연도
+     * @param month 급여 대상 월
+     * @param empType 근로자 유형
+     * @param payCycle 급여 주기 (nullable, null이면 조건에서 제외)
+     * @param pageable 페이징 정보
+     * @return 급여 목록 (페이징)
+     */
+    @Query("SELECT p FROM Payroll p " +
+            "WHERE p.siteId = :siteId " +
+            "AND p.salaryYear = :year " +
+            "AND p.salaryMonth = :month " +
+            "AND p.empType = :empType " +
+            "AND (:payCycle IS NULL OR p.payCycle = :payCycle) " +
+            "ORDER BY p.createdAt DESC")
+    Page<Payroll> findBySiteAndPeriodAndType(
+            @Param("siteId") Long siteId,
+            @Param("year") Integer year,
+            @Param("month") Integer month,
+            @Param("empType") EmpType empType,
+            @Param("payCycle") @Nullable PayPeriod payCycle,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/concrete/buildup/domain/payroll/service/PayrollService.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/service/PayrollService.java
@@ -1,0 +1,152 @@
+package com.concrete.buildup.domain.payroll.service;
+
+import com.concrete.buildup.domain.contract.enums.EmpType;
+import com.concrete.buildup.domain.contract.enums.PayPeriod;
+import com.concrete.buildup.domain.payroll.dto.SalaryHistoryItemResponse;
+import com.concrete.buildup.domain.payroll.dto.SalaryHistorySummaryResponse;
+import com.concrete.buildup.domain.payroll.entity.Payroll;
+import com.concrete.buildup.domain.payroll.enums.PayStatus;
+import com.concrete.buildup.domain.payroll.repository.PayrollRepository;
+import com.concrete.buildup.domain.payroll.util.ResidentNoMasker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 급여 조회 서비스
+ *
+ * <p>급여 내역 조회 및 통계 정보를 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PayrollService {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
+
+    private final PayrollRepository payrollRepository;
+
+    /**
+     * 현장별 기간별 급여 내역 조회 (상용직/일용직 공통)
+     *
+     * <p>급여 내역 목록과 함께 전체 통계 정보(총 건수, 미지급 건수, 총 지급액)를 반환합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param year 급여 대상 연도
+     * @param month 급여 대상 월
+     * @param empType 근로자 유형 (PERMANENT: 상용직, DAILY: 일용직)
+     * @param payCycle 급여 주기 (상용직: null, 일용직: MONTHLY/WEEKLY/DAILY)
+     * @param pageable 페이징 정보
+     * @return 급여 내역 요약 정보 (통계 + 목록)
+     */
+    public SalaryHistorySummaryResponse getSalaryHistory(
+            Long siteId,
+            Integer year,
+            Integer month,
+            EmpType empType,
+            @Nullable PayPeriod payCycle,
+            Pageable pageable
+    ) {
+        log.debug("급여 내역 조회 - siteId: {}, year: {}, month: {}, empType: {}, payCycle: {}",
+                siteId, year, month, empType, payCycle);
+
+        // 1. 급여 내역 조회
+        Page<Payroll> payrollPage = payrollRepository.findBySiteAndPeriodAndType(
+                siteId, year, month, empType, payCycle, pageable
+        );
+
+        // 2. DTO 변환
+        List<SalaryHistoryItemResponse> items = payrollPage.getContent().stream()
+                .map(this::toItemResponse)
+                .collect(Collectors.toList());
+
+        // 3. 통계 계산
+        int totalCount = (int) payrollPage.getTotalElements();
+        int unpaidCount = calculateUnpaidCount(payrollPage.getContent());
+        BigDecimal totalPaidAmount = calculateTotalPaidAmount(payrollPage.getContent());
+
+        log.debug("급여 내역 조회 완료 - totalCount: {}, unpaidCount: {}, totalPaidAmount: {}",
+                totalCount, unpaidCount, totalPaidAmount);
+
+        return SalaryHistorySummaryResponse.builder()
+                .totalCount(totalCount)
+                .unpaidCount(unpaidCount)
+                .totalPaidAmount(totalPaidAmount)
+                .data(items)
+                .build();
+    }
+
+    /**
+     * Payroll 엔티티를 SalaryHistoryItemResponse DTO로 변환
+     *
+     * @param payroll 급여 엔티티
+     * @return 급여 내역 항목 DTO
+     */
+    private SalaryHistoryItemResponse toItemResponse(Payroll payroll) {
+        return SalaryHistoryItemResponse.builder()
+                .employeeId(payroll.getEmployeeId())
+                .name(payroll.getEmpName())
+                .residentId(ResidentNoMasker.mask(payroll.getResidentNum()))
+                .payDate(formatPayDate(payroll.getPayDueDate()))
+                .totalPay(payroll.getTotalPay())
+                .nonTaxIncome(payroll.getNoneTaxIncome())
+                .taxIncome(payroll.getIncomeTax())
+                .localTax(payroll.getResidentTax())
+                .paid(payroll.getPayStatus() == PayStatus.PAID)
+                .payslipAvailable(payroll.getS3Key() != null && !payroll.getS3Key().isEmpty())
+                .payCycle(payroll.getPayCycle())
+                .build();
+    }
+
+    /**
+     * 지급일 포맷팅 (yy.MM.dd)
+     *
+     * @param payDueDate 지급 예정일
+     * @return 포맷팅된 날짜 문자열 (null이면 null 반환)
+     */
+    private String formatPayDate(java.time.LocalDate payDueDate) {
+        if (payDueDate == null) {
+            return null;
+        }
+        return payDueDate.format(DATE_FORMATTER);
+    }
+
+    /**
+     * 미지급 건수 계산
+     *
+     * @param payrolls 급여 목록
+     * @return 미지급 건수
+     */
+    private int calculateUnpaidCount(List<Payroll> payrolls) {
+        return (int) payrolls.stream()
+                .filter(p -> p.getPayStatus() != PayStatus.PAID)
+                .count();
+    }
+
+    /**
+     * 총 지급액 계산 (지급 완료된 금액의 합계)
+     *
+     * @param payrolls 급여 목록
+     * @return 총 지급액
+     */
+    private BigDecimal calculateTotalPaidAmount(List<Payroll> payrolls) {
+        return payrolls.stream()
+                .filter(p -> p.getPayStatus() == PayStatus.PAID)
+                .map(Payroll::getTotalPay)
+                .filter(amount -> amount != null)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/payroll/service/PayrollService.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/service/PayrollService.java
@@ -73,10 +73,14 @@ public class PayrollService {
                 .map(this::toItemResponse)
                 .collect(Collectors.toList());
 
-        // 3. 통계 계산
+        // 3. 전체 데이터셋 기준 통계 조회
         int totalCount = (int) payrollPage.getTotalElements();
-        int unpaidCount = calculateUnpaidCount(payrollPage.getContent());
-        BigDecimal totalPaidAmount = calculateTotalPaidAmount(payrollPage.getContent());
+        int unpaidCount = (int) payrollRepository.countUnpaidBySiteAndPeriodAndType(
+                siteId, year, month, empType, payCycle
+        );
+        BigDecimal totalPaidAmount = payrollRepository.sumTotalPaidAmountBySiteAndPeriodAndType(
+                siteId, year, month, empType, payCycle
+        );
 
         log.debug("급여 내역 조회 완료 - totalCount: {}, unpaidCount: {}, totalPaidAmount: {}",
                 totalCount, unpaidCount, totalPaidAmount);
@@ -122,31 +126,5 @@ public class PayrollService {
             return null;
         }
         return payDueDate.format(DATE_FORMATTER);
-    }
-
-    /**
-     * 미지급 건수 계산
-     *
-     * @param payrolls 급여 목록
-     * @return 미지급 건수
-     */
-    private int calculateUnpaidCount(List<Payroll> payrolls) {
-        return (int) payrolls.stream()
-                .filter(p -> p.getPayStatus() != PayStatus.PAID)
-                .count();
-    }
-
-    /**
-     * 총 지급액 계산 (지급 완료된 금액의 합계)
-     *
-     * @param payrolls 급여 목록
-     * @return 총 지급액
-     */
-    private BigDecimal calculateTotalPaidAmount(List<Payroll> payrolls) {
-        return payrolls.stream()
-                .filter(p -> p.getPayStatus() == PayStatus.PAID)
-                .map(Payroll::getTotalPay)
-                .filter(amount -> amount != null)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/payroll/util/ResidentNoMasker.java
+++ b/src/main/java/com/concrete/buildup/domain/payroll/util/ResidentNoMasker.java
@@ -1,0 +1,44 @@
+package com.concrete.buildup.domain.payroll.util;
+
+/**
+ * 주민등록번호 마스킹 유틸리티
+ *
+ * <p>주민등록번호를 개인정보 보호를 위해 마스킹 처리합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+public class ResidentNoMasker {
+
+    private ResidentNoMasker() {
+        // 유틸리티 클래스 인스턴스화 방지
+    }
+
+    /**
+     * 주민등록번호 마스킹 처리
+     *
+     * <p>뒷자리 7자리를 '*'로 마스킹합니다.</p>
+     *
+     * <pre>
+     * 예시:
+     * - 입력: "850101-1234567"
+     * - 출력: "850101-1******"
+     * </pre>
+     *
+     * @param residentNo 원본 주민등록번호 (형식: YYMMDD-NNNNNNN)
+     * @return 마스킹된 주민등록번호 (형식: YYMMDD-N******, null이면 null 반환)
+     */
+    public static String mask(String residentNo) {
+        if (residentNo == null || residentNo.isEmpty()) {
+            return null;
+        }
+
+        // 하이픈 포함 14자리 형식 체크
+        if (residentNo.length() != 14 || residentNo.charAt(6) != '-') {
+            return residentNo; // 형식이 맞지 않으면 원본 반환
+        }
+
+        // 앞 8자리(생년월일 6자리 + 하이픈 + 성별 1자리) + 6개의 '*'
+        return residentNo.substring(0, 8) + "******";
+    }
+}

--- a/src/main/resources/db/migration/V7__add_site_id_to_payrolls.sql
+++ b/src/main/resources/db/migration/V7__add_site_id_to_payrolls.sql
@@ -1,0 +1,18 @@
+-- V7: payrolls 테이블에 site_id 컬럼 및 기간별 조회 인덱스 추가
+-- 급여 내역 조회 API (BU-155)
+
+-- 1. site_id 컬럼 추가
+ALTER TABLE payrolls
+ADD COLUMN site_id BIGINT NOT NULL COMMENT '현장 ID'
+AFTER corporation_id;
+
+-- 2. site_id 외래키 제약조건 추가
+ALTER TABLE payrolls
+ADD CONSTRAINT fk_payrolls_site
+FOREIGN KEY (site_id) REFERENCES sites(id);
+
+-- 3. site_id 단일 인덱스 추가
+CREATE INDEX idx_site_id ON payrolls(site_id);
+
+-- 4. 기간별 조회 최적화를 위한 복합 인덱스 추가
+CREATE INDEX idx_period_search ON payrolls(site_id, salary_year, salary_month, emp_type, pay_cycle);

--- a/src/test/java/com/concrete/buildup/domain/payroll/controller/PayrollControllerTest.java
+++ b/src/test/java/com/concrete/buildup/domain/payroll/controller/PayrollControllerTest.java
@@ -1,0 +1,230 @@
+package com.concrete.buildup.domain.payroll.controller;
+
+import com.concrete.buildup.domain.contract.enums.EmpType;
+import com.concrete.buildup.domain.contract.enums.PayPeriod;
+import com.concrete.buildup.domain.payroll.dto.SalaryHistoryItemResponse;
+import com.concrete.buildup.domain.payroll.dto.SalaryHistorySummaryResponse;
+import com.concrete.buildup.domain.payroll.service.PayrollService;
+import com.concrete.buildup.global.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * PayrollController 단위 테스트
+ */
+@WebMvcTest(PayrollController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@DisplayName("PayrollController 단위 테스트")
+class PayrollControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PayrollService payrollService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    @DisplayName("상용직 급여 내역 조회 - 성공")
+    void getPermanentSalaryHistory_Success() throws Exception {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+        Integer page = 1;
+        Integer size = 20;
+
+        SalaryHistorySummaryResponse mockResponse = createMockResponse();
+
+        given(payrollService.getSalaryHistory(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(PageRequest.of(0, 20))
+        )).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/v1/payrolls/period/permanent")
+                        .param("siteId", siteId.toString())
+                        .param("year", year.toString())
+                        .param("month", month.toString())
+                        .param("page", page.toString())
+                        .param("size", size.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(3))
+                .andExpect(jsonPath("$.unpaidCount").value(1))
+                .andExpect(jsonPath("$.totalPaidAmount").value(5000000))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].employeeId").value(1))
+                .andExpect(jsonPath("$.data[0].name").value("김철수"))
+                .andExpect(jsonPath("$.data[0].residentId").value("850101-1******"))
+                .andExpect(jsonPath("$.data[0].paid").value(true))
+                .andExpect(jsonPath("$.data[0].payCycle").value("MONTHLY"));
+
+        verify(payrollService).getSalaryHistory(
+                siteId, year, month, EmpType.PERMANENT, null, PageRequest.of(0, 20)
+        );
+    }
+
+    @Test
+    @DisplayName("상용직 급여 내역 조회 - 기본 페이징 값")
+    void getPermanentSalaryHistory_DefaultPagination() throws Exception {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+
+        SalaryHistorySummaryResponse mockResponse = createMockResponse();
+
+        given(payrollService.getSalaryHistory(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(PageRequest.of(0, 20))
+        )).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/v1/payrolls/period/permanent")
+                        .param("siteId", siteId.toString())
+                        .param("year", year.toString())
+                        .param("month", month.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(3));
+
+        verify(payrollService).getSalaryHistory(
+                siteId, year, month, EmpType.PERMANENT, null, PageRequest.of(0, 20)
+        );
+    }
+
+    @Test
+    @DisplayName("상용직 급여 내역 조회 - 필수 파라미터 누락 시 400 에러")
+    void getPermanentSalaryHistory_MissingRequiredParam() throws Exception {
+        // when & then
+        mockMvc.perform(get("/v1/payrolls/period/permanent")
+                        .param("year", "2025")
+                        .param("month", "11")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("상용직 급여 내역 조회 - 커스텀 페이징")
+    void getPermanentSalaryHistory_CustomPagination() throws Exception {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+        Integer page = 2;
+        Integer size = 10;
+
+        SalaryHistorySummaryResponse mockResponse = createMockResponse();
+
+        given(payrollService.getSalaryHistory(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(PageRequest.of(1, 10))
+        )).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/v1/payrolls/period/permanent")
+                        .param("siteId", siteId.toString())
+                        .param("year", year.toString())
+                        .param("month", month.toString())
+                        .param("page", page.toString())
+                        .param("size", size.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(payrollService).getSalaryHistory(
+                siteId, year, month, EmpType.PERMANENT, null, PageRequest.of(1, 10)
+        );
+    }
+
+    @Test
+    @DisplayName("상용직 급여 내역 조회 - 빈 결과")
+    void getPermanentSalaryHistory_EmptyResult() throws Exception {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+
+        SalaryHistorySummaryResponse emptyResponse = SalaryHistorySummaryResponse.builder()
+                .totalCount(0)
+                .unpaidCount(0)
+                .totalPaidAmount(BigDecimal.ZERO)
+                .data(List.of())
+                .build();
+
+        given(payrollService.getSalaryHistory(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), any(PageRequest.class)
+        )).willReturn(emptyResponse);
+
+        // when & then
+        mockMvc.perform(get("/v1/payrolls/period/permanent")
+                        .param("siteId", siteId.toString())
+                        .param("year", year.toString())
+                        .param("month", month.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(0))
+                .andExpect(jsonPath("$.unpaidCount").value(0))
+                .andExpect(jsonPath("$.totalPaidAmount").value(0))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    // ========== 테스트 데이터 생성 헬퍼 메서드 ==========
+
+    private SalaryHistorySummaryResponse createMockResponse() {
+        List<SalaryHistoryItemResponse> items = Arrays.asList(
+                createItem(1L, "김철수", "850101-1******", new BigDecimal("2500000"), true),
+                createItem(2L, "이영희", "900315-2******", new BigDecimal("2500000"), true),
+                createItem(3L, "박민수", "920520-1******", new BigDecimal("3000000"), false)
+        );
+
+        return SalaryHistorySummaryResponse.builder()
+                .totalCount(3)
+                .unpaidCount(1)
+                .totalPaidAmount(new BigDecimal("5000000"))
+                .data(items)
+                .build();
+    }
+
+    private SalaryHistoryItemResponse createItem(Long employeeId, String name, String residentId,
+                                                  BigDecimal totalPay, boolean paid) {
+        return SalaryHistoryItemResponse.builder()
+                .employeeId(employeeId)
+                .name(name)
+                .residentId(residentId)
+                .payDate("25.11.25")
+                .totalPay(totalPay)
+                .nonTaxIncome(new BigDecimal("100000"))
+                .taxIncome(new BigDecimal("50000"))
+                .localTax(new BigDecimal("5000"))
+                .paid(paid)
+                .payslipAvailable(true)
+                .payCycle(PayPeriod.MONTHLY)
+                .build();
+    }
+}

--- a/src/test/java/com/concrete/buildup/domain/payroll/service/PayrollServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/payroll/service/PayrollServiceTest.java
@@ -1,0 +1,224 @@
+package com.concrete.buildup.domain.payroll.service;
+
+import com.concrete.buildup.domain.contract.enums.EmpType;
+import com.concrete.buildup.domain.contract.enums.PayPeriod;
+import com.concrete.buildup.domain.payroll.dto.SalaryHistorySummaryResponse;
+import com.concrete.buildup.domain.payroll.entity.Payroll;
+import com.concrete.buildup.domain.payroll.enums.PayStatus;
+import com.concrete.buildup.domain.payroll.repository.PayrollRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * PayrollService 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PayrollService 단위 테스트")
+class PayrollServiceTest {
+
+    @Mock
+    private PayrollRepository payrollRepository;
+
+    @InjectMocks
+    private PayrollService payrollService;
+
+    @Test
+    @DisplayName("상용직 급여 내역 조회 - 성공")
+    void getSalaryHistory_Permanent_Success() {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        List<Payroll> payrolls = createTestPayrolls();
+        Page<Payroll> payrollPage = new PageImpl<>(payrolls, pageable, payrolls.size());
+
+        given(payrollRepository.findBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
+        )).willReturn(payrollPage);
+
+        // when
+        SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
+                siteId, year, month, EmpType.PERMANENT, null, pageable
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getTotalCount()).isEqualTo(3);
+        assertThat(response.getUnpaidCount()).isEqualTo(1); // 1개는 PENDING
+        assertThat(response.getTotalPaidAmount()).isEqualByComparingTo(new BigDecimal("5000000")); // 2개 PAID의 합계
+        assertThat(response.getData()).hasSize(3);
+
+        verify(payrollRepository).findBySiteAndPeriodAndType(
+                siteId, year, month, EmpType.PERMANENT, null, pageable
+        );
+    }
+
+    @Test
+    @DisplayName("급여 내역 조회 - 빈 목록")
+    void getSalaryHistory_EmptyList() {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Page<Payroll> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        given(payrollRepository.findBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
+        )).willReturn(emptyPage);
+
+        // when
+        SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
+                siteId, year, month, EmpType.PERMANENT, null, pageable
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getTotalCount()).isZero();
+        assertThat(response.getUnpaidCount()).isZero();
+        assertThat(response.getTotalPaidAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(response.getData()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("급여 내역 조회 - 모두 미지급")
+    void getSalaryHistory_AllUnpaid() {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        List<Payroll> payrolls = Arrays.asList(
+                createPayroll(1L, "김철수", "850101-1******", new BigDecimal("2500000"), PayStatus.PENDING),
+                createPayroll(2L, "이영희", "900315-2******", new BigDecimal("2500000"), PayStatus.PENDING)
+        );
+        Page<Payroll> payrollPage = new PageImpl<>(payrolls, pageable, payrolls.size());
+
+        given(payrollRepository.findBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
+        )).willReturn(payrollPage);
+
+        // when
+        SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
+                siteId, year, month, EmpType.PERMANENT, null, pageable
+        );
+
+        // then
+        assertThat(response.getTotalCount()).isEqualTo(2);
+        assertThat(response.getUnpaidCount()).isEqualTo(2);
+        assertThat(response.getTotalPaidAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("급여 내역 조회 - 일용직 월급")
+    void getSalaryHistory_DailyMonthly() {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        List<Payroll> payrolls = createTestPayrolls();
+        Page<Payroll> payrollPage = new PageImpl<>(payrolls, pageable, payrolls.size());
+
+        given(payrollRepository.findBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.DAILY), eq(PayPeriod.MONTHLY), eq(pageable)
+        )).willReturn(payrollPage);
+
+        // when
+        SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
+                siteId, year, month, EmpType.DAILY, PayPeriod.MONTHLY, pageable
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getTotalCount()).isEqualTo(3);
+        verify(payrollRepository).findBySiteAndPeriodAndType(
+                siteId, year, month, EmpType.DAILY, PayPeriod.MONTHLY, pageable
+        );
+    }
+
+    @Test
+    @DisplayName("DTO 변환 - 주민번호 마스킹 확인")
+    void toItemResponse_ResidentNoMasking() {
+        // given
+        Long siteId = 1L;
+        Integer year = 2025;
+        Integer month = 11;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Payroll payroll = createPayroll(1L, "김철수", "850101-1234567", new BigDecimal("2500000"), PayStatus.PAID);
+        Page<Payroll> payrollPage = new PageImpl<>(List.of(payroll), pageable, 1);
+
+        given(payrollRepository.findBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
+        )).willReturn(payrollPage);
+
+        // when
+        SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
+                siteId, year, month, EmpType.PERMANENT, null, pageable
+        );
+
+        // then
+        assertThat(response.getData()).hasSize(1);
+        assertThat(response.getData().get(0).getResidentId()).isEqualTo("850101-1******");
+    }
+
+    // ========== 테스트 데이터 생성 헬퍼 메서드 ==========
+
+    private List<Payroll> createTestPayrolls() {
+        return Arrays.asList(
+                createPayroll(1L, "김철수", "850101-1******", new BigDecimal("2500000"), PayStatus.PAID),
+                createPayroll(2L, "이영희", "900315-2******", new BigDecimal("2500000"), PayStatus.PAID),
+                createPayroll(3L, "박민수", "920520-1******", new BigDecimal("3000000"), PayStatus.PENDING)
+        );
+    }
+
+    private Payroll createPayroll(Long employeeId, String name, String residentNum,
+                                   BigDecimal totalPay, PayStatus payStatus) {
+        return Payroll.builder()
+                .employeeId(employeeId)
+                .contractId(1L)
+                .corporationId(1L)
+                .siteId(1L)
+                .salaryYear(2025)
+                .salaryMonth(11)
+                .salaryWeek(0)
+                .salaryDay(LocalDate.of(2025, 11, 1))
+                .searchDate(LocalDate.of(2025, 11, 1))
+                .payDueDate(LocalDate.of(2025, 11, 25))
+                .empType(EmpType.PERMANENT)
+                .empName(name)
+                .residentNum(residentNum)
+                .totalPay(totalPay)
+                .noneTaxIncome(new BigDecimal("100000"))
+                .incomeTax(new BigDecimal("50000"))
+                .residentTax(new BigDecimal("5000"))
+                .payCycle(PayPeriod.MONTHLY)
+                .payStatus(payStatus)
+                .s3Key("payroll/test/2025/11/salary-" + employeeId + ".pdf")
+                .build();
+    }
+}

--- a/src/test/java/com/concrete/buildup/domain/payroll/service/PayrollServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/payroll/service/PayrollServiceTest.java
@@ -56,6 +56,14 @@ class PayrollServiceTest {
                 eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
         )).willReturn(payrollPage);
 
+        given(payrollRepository.countUnpaidBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(1L);
+
+        given(payrollRepository.sumTotalPaidAmountBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(new BigDecimal("5000000"));
+
         // when
         SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
                 siteId, year, month, EmpType.PERMANENT, null, pageable
@@ -64,12 +72,18 @@ class PayrollServiceTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.getTotalCount()).isEqualTo(3);
-        assertThat(response.getUnpaidCount()).isEqualTo(1); // 1개는 PENDING
-        assertThat(response.getTotalPaidAmount()).isEqualByComparingTo(new BigDecimal("5000000")); // 2개 PAID의 합계
+        assertThat(response.getUnpaidCount()).isEqualTo(1); // 전체 기준 미지급 건수
+        assertThat(response.getTotalPaidAmount()).isEqualByComparingTo(new BigDecimal("5000000")); // 전체 기준 지급액
         assertThat(response.getData()).hasSize(3);
 
         verify(payrollRepository).findBySiteAndPeriodAndType(
                 siteId, year, month, EmpType.PERMANENT, null, pageable
+        );
+        verify(payrollRepository).countUnpaidBySiteAndPeriodAndType(
+                siteId, year, month, EmpType.PERMANENT, null
+        );
+        verify(payrollRepository).sumTotalPaidAmountBySiteAndPeriodAndType(
+                siteId, year, month, EmpType.PERMANENT, null
         );
     }
 
@@ -87,6 +101,14 @@ class PayrollServiceTest {
         given(payrollRepository.findBySiteAndPeriodAndType(
                 eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
         )).willReturn(emptyPage);
+
+        given(payrollRepository.countUnpaidBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(0L);
+
+        given(payrollRepository.sumTotalPaidAmountBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(BigDecimal.ZERO);
 
         // when
         SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
@@ -120,6 +142,14 @@ class PayrollServiceTest {
                 eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
         )).willReturn(payrollPage);
 
+        given(payrollRepository.countUnpaidBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(2L);
+
+        given(payrollRepository.sumTotalPaidAmountBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(BigDecimal.ZERO);
+
         // when
         SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
                 siteId, year, month, EmpType.PERMANENT, null, pageable
@@ -147,6 +177,14 @@ class PayrollServiceTest {
                 eq(siteId), eq(year), eq(month), eq(EmpType.DAILY), eq(PayPeriod.MONTHLY), eq(pageable)
         )).willReturn(payrollPage);
 
+        given(payrollRepository.countUnpaidBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.DAILY), eq(PayPeriod.MONTHLY)
+        )).willReturn(1L);
+
+        given(payrollRepository.sumTotalPaidAmountBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.DAILY), eq(PayPeriod.MONTHLY)
+        )).willReturn(new BigDecimal("5000000"));
+
         // when
         SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(
                 siteId, year, month, EmpType.DAILY, PayPeriod.MONTHLY, pageable
@@ -157,6 +195,12 @@ class PayrollServiceTest {
         assertThat(response.getTotalCount()).isEqualTo(3);
         verify(payrollRepository).findBySiteAndPeriodAndType(
                 siteId, year, month, EmpType.DAILY, PayPeriod.MONTHLY, pageable
+        );
+        verify(payrollRepository).countUnpaidBySiteAndPeriodAndType(
+                siteId, year, month, EmpType.DAILY, PayPeriod.MONTHLY
+        );
+        verify(payrollRepository).sumTotalPaidAmountBySiteAndPeriodAndType(
+                siteId, year, month, EmpType.DAILY, PayPeriod.MONTHLY
         );
     }
 
@@ -175,6 +219,14 @@ class PayrollServiceTest {
         given(payrollRepository.findBySiteAndPeriodAndType(
                 eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull(), eq(pageable)
         )).willReturn(payrollPage);
+
+        given(payrollRepository.countUnpaidBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(0L);
+
+        given(payrollRepository.sumTotalPaidAmountBySiteAndPeriodAndType(
+                eq(siteId), eq(year), eq(month), eq(EmpType.PERMANENT), isNull()
+        )).willReturn(new BigDecimal("2500000"));
 
         // when
         SalaryHistorySummaryResponse response = payrollService.getSalaryHistory(


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
<!-- Jira Story/Bug 링크를 작성해주세요 -->
- Jira: [BU-155](https://your-jira-domain.atlassian.net/browse/BU-155)

## 📝 변경 사항 요약

상용직 급여 내역을 연도/월/현장 기준으로 조회하는 기간별 급여 조회 API (Regular Payroll History API) 를 신규 구현했습니다.
UI 화면(급여내역_기간별 조회_상용직)에 맞춰 총 인원, 총 지급액, 미지급 인원 등 급여 통계 계산 및 목록 조회 기능을 제공합니다.

### 주요 변경사항
	•	상용직 급여 기간별 조회 엔드포인트 추가 (GET /v1/payrolls/period/regular)
	•	급여 조회용 공통 DTO 개발 (SalaryHistorySummaryResponse, SalaryHistoryItemResponse)
	•	급여 조회 서비스 및 Repository 필터링/합산 로직 구현

⸻

### 🎯 변경 목적
	•	상용직 급여 내역을 월별 기준으로 조회하는 화면 기능을 백엔드에서 지원하기 위함
	•	관리자가 현장의 급여 지급 현황(총 지급액/미지급 인원 등)을 쉽게 파악할 수 있도록 통계 정보 제공
	•	향후 일용직(월급/주급/일급) API 확장 시 재사용 가능한 구조 기반 마련

⸻

## 🔍 변경 내역 상세

### ➕ 추가된 기능 (Features)
	•	상용직 급여 기간별 조회 API 구현
	•	siteId, year, month 기준 급여 데이터 조회
	•	총 지급액, 미지급 인원 수 계산 로직 포함
	•	주민번호 마스킹 처리 적용
	•	급여 조회 응답 DTO 추가
	•	SalaryHistoryItemResponse
	•	SalaryHistorySummaryResponse
	•	급여 조회 서비스 구현 (SalaryHistoryService)
	•	필터링, 페이징, 합계 계산 처리

### 🐞 버그 수정 (Bug Fixes)
	•	없음

### 🛠 리팩토링 (Refactoring)
	•	급여 조회 흐름을 공통화하여 이후 일용직 급여 조회까지 확장 가능하도록 구조 정리
	•	일부 변수 및 네이밍 정리

### 📄 기타 변경사항 (Others)
	•	주민번호 마스킹 유틸(ResidentNumberMasker) 추가
	•	Swagger 문서 일부 업데이트

⸻

## 🧪 테스트 방법

### ✔ 단위 테스트
	•	급여 목록 조회 정상 로직 검증
	•	총 인원 / 총 지급액 / unpaidCount 계산 테스트
	•	주민번호 마스킹 테스트
	•	테스트 커버리지: 추가 예정

### ✔ 수동 테스트
	1.	Postman 또는 Swagger 접속
	2.	다음 요청 실행

GET /v1/payrolls/period/regular?siteId=1&year=2025&month=9&page=1&size=10


	3.	다음 값 검증
	•	totalCount / unpaidCount / totalPaidAmount
	•	paid=true/false 여부
	•	주민번호 마스킹 적용 여부

✔ API 테스트 예시

curl -X GET "http://localhost:8080/v1/payrolls/period/regular?siteId=1&year=2025&month=9&page=1&size=10"

예상 결과 예시:

{
  "totalCount": 20,
  "unpaidCount": 2,
  "totalPaidAmount": 50180000,
  "data": [
    {
      "employeeId": 1301,
      "name": "박영희",
      "residentId": "920315-2******",
      "payDate": "25.09.12",
      "totalPay": 2509000,
      "nonTaxIncome": 180000,
      "taxIncome": 20000,
      "localTax": 1200,
      "paid": true,
      "payslipAvailable": true
    }
  ]
}


⸻

## 📸 스크린샷

(필요 시 Swagger 요청 결과나 UI 캡처 추가)

⸻

## ⚠️ Breaking Changes
	•	Breaking Changes 없음
	•	Breaking Changes 있음

⸻

## 🔗 의존성 변경
	•	의존성 변경 없음
	•	의존성 변경 있음

⸻

## 🗄️ 데이터베이스 변경
	•	DB 변경 없음
	•	Flyway 마이그레이션 포함

⸻

## ✅ 체크리스트

### 코드 품질
	•	코드 스타일 가이드 준수
	•	Lombok 사용
	•	불필요한 주석 제거
	•	하드코딩 제거
	•	로그 레벨 점검

### 테스트
	•	단위 테스트 일부 작성
	•	통합 테스트는 단계적으로 추가 예정
	•	빌드 성공 확인

### 보안
	•	SQL Injection 방지 (JPA / QueryDSL 사용)
	•	주민번호 마스킹 적용
	•	인증/인가 필터 적용 확인

### 성능
	•	N+1 문제 없음 (필요 컬럼만 조회)
	•	향후 인덱스 최적화 예정

### 문서
	•	Swagger API 문서화
	•	README 추가는 추후 일괄 진행

### Git
	•	Conventional Commits 준수
	•	develop 브랜치 리베이스 완료
	•	충돌 해결 완료

⸻

## 📌 리뷰어에게
	•	구조를 일용직 급여 조회에도 재사용 가능하도록 설계했습니다.
서비스 계층 분리가 적절한지 검토해주시면 좋겠습니다.
	•	성능이나 조회 조건 확장(현장 필터 외 추가 조건)이 필요하면 의견 주세요.

⸻

## 🔗 관련 PR/Issue

Related Issue close : #77 

⸻

📚 참고 자료
	•	급여내역_기간별 조회 UI (Figma)
	•	Build-Up 급여 관리 요구사항 문서

[BU-155]: https://build-up-project.atlassian.net/browse/BU-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사이트별·기간별 영구직 급여 조회 API(페이징 포함) 및 통계(총건수·미지급건수·총지급액) 제공
  * 응답에 개별 급여 항목 추가(지급일, 총지급액 등)
  * 주민등록번호 마스킹 적용으로 개인정보 보호 강화
  * 데이터베이스에 사이트 식별자 추가 및 기간 조회용 인덱스 추가로 조회 최적화

* **테스트**
  * 컨트롤러 및 서비스 단위 테스트 추가 및 시나리오 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->