### PR TITLE
fix: 테스트 환경 설정 및 S3Service MockBean 추가

### DIFF
--- a/src/test/java/com/concrete/buildup/domain/auth/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/concrete/buildup/domain/auth/integration/AuthIntegrationTest.java
@@ -13,6 +13,7 @@ import com.concrete.buildup.domain.auth.repository.RoleRepository;
 import com.concrete.buildup.domain.auth.repository.UserRepository;
 import com.concrete.buildup.domain.site.entity.Site;
 import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.domain.upload.service.S3Service;
 import com.concrete.buildup.global.util.JwtTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
@@ -91,6 +93,9 @@ class AuthIntegrationTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private S3Service s3Service;
 
     private Role employeeRole;
     private Role managerRole;


### PR DESCRIPTION
## Summary
- AuthIntegrationTest에 S3Service MockBean 추가하여 테스트 의존성 해결
- EmployeeFaceServiceTest의 S3 검증 로직 및 경로 수정
- 테스트 환경 설정 개선

## Changes
- ✅ AuthIntegrationTest에 `@MockBean S3Service` 추가
- ✅ EmployeeFaceServiceTest S3 검증 로직 수정
- ✅ 테스트 환경 설정 및 검증 로직 개선

## Test Plan
- [x] 로컬 환경에서 `./gradlew clean test` 통과 확인
- [x] GitHub Actions CI 환경과 동일한 환경변수로 테스트 통과 확인
  ```bash
  SPRING_PROFILES_ACTIVE=test \
  JWT_SECRET=test-secret-key-min-256-bits-long-for-hs256-algorithm-test \
  ENCRYPTION_KEY=0123456789abcdef0123456789abcdef \
  ./gradlew test --no-daemon
  ```
- [ ] GitHub Actions CI 통과 확인 (자동 실행 예정)

## Related Issues
Refs: BU-154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 인증 통합 테스트의 테스트 인프라 개선

---

**참고**: 이번 변경사항은 내부 테스트 환경 개선으로 사용자에게 직접적인 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->