### PR TITLE
[BU-170] 출퇴근 및 로그인 API 개선

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/attendance/service/EmployeeFaceService.java
+++ b/src/main/java/com/concrete/buildup/domain/attendance/service/EmployeeFaceService.java
@@ -6,6 +6,7 @@ import com.concrete.buildup.domain.auth.repository.EmployeeRepository;
 import com.concrete.buildup.domain.auth.repository.UserRepository;
 import com.concrete.buildup.global.exception.BusinessException;
 import com.concrete.buildup.global.exception.errorcode.AuthErrorCode;
+import com.concrete.buildup.global.exception.errorcode.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,7 +35,7 @@ public class EmployeeFaceService {
 
     private final UserRepository userRepository;
     private final EmployeeRepository employeeRepository;
-    private final com.concrete.buildup.domain.upload.service.S3Service s3Service;
+    private final java.util.Optional<com.concrete.buildup.domain.upload.service.S3Service> s3Service;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
@@ -65,7 +66,10 @@ public class EmployeeFaceService {
             });
 
         // 3. S3에 파일이 실제로 존재하는지 검증
-        if (!s3Service.doesObjectExist(uploadId)) {
+        com.concrete.buildup.domain.upload.service.S3Service service = s3Service.orElseThrow(() ->
+                new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR, "S3 서비스가 비활성화되어 있습니다."));
+
+        if (!service.doesObjectExist(uploadId)) {
             log.error("S3에 파일이 존재하지 않음 - uploadId: {}", uploadId);
             throw new BusinessException(AuthErrorCode.USER_NOT_FOUND,
                     "업로드된 이미지 파일이 S3에 존재하지 않습니다. 파일을 먼저 업로드해주세요.");

--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -197,7 +197,7 @@ public class AuthController {
         boolean isProduction = !environment.acceptsProfiles(org.springframework.core.env.Profiles.of("dev", "local"));
 
         // Access Token을 HttpOnly 쿠키로 설정 (XSS 방어)
-        org.springframework.http.ResponseCookie accessTokenCookie = org.springframework.http.ResponseCookie.from("accessToken", loginResult.getLoginResponse().getAccessToken())
+        org.springframework.http.ResponseCookie accessTokenCookie = org.springframework.http.ResponseCookie.from("accessToken", loginResult.getAccessToken())
                 .httpOnly(true)          // XSS 공격 방어
                 .secure(isProduction)    // 운영: HTTPS 필수, 개발: HTTP 허용
                 .path("/")               // 모든 경로에서 접근 가능
@@ -289,7 +289,7 @@ public class AuthController {
         boolean isProduction = !environment.acceptsProfiles(org.springframework.core.env.Profiles.of("dev", "local"));
 
         // 새로운 Access Token을 HttpOnly 쿠키로 설정
-        org.springframework.http.ResponseCookie accessTokenCookie = org.springframework.http.ResponseCookie.from("accessToken", loginResult.getLoginResponse().getAccessToken())
+        org.springframework.http.ResponseCookie accessTokenCookie = org.springframework.http.ResponseCookie.from("accessToken", loginResult.getAccessToken())
                 .httpOnly(true)          // XSS 공격 방어
                 .secure(isProduction)    // 운영: HTTPS 필수, 개발: HTTP 허용
                 .path("/")               // 모든 경로에서 접근 가능

--- a/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/controller/AuthController.java
@@ -172,16 +172,16 @@ public class AuthController {
      * 로그인 API
      *
      * <p>근로자, 현장 관리자, 기업 관리자 공통 로그인 API입니다.</p>
-     * <p>Access Token은 응답 Body에, Refresh Token은 HttpOnly 쿠키로 전달됩니다.</p>
+     * <p>Access Token과 Refresh Token은 모두 HttpOnly 쿠키로 전달됩니다.</p>
      *
      * @param request 로그인 요청 정보
      * @param response HTTP 응답 (쿠키 설정용)
-     * @return LoginResponse - Access Token과 사용자 정보
+     * @return LoginResponse - 사용자 정보 (토큰은 쿠키로 전달)
      */
     @Operation(
             summary = "로그인",
             description = "근로자, 현장 관리자, 기업 관리자 공통 로그인 API입니다. " +
-                    "Access Token은 응답 Body에 포함되며, Refresh Token은 HttpOnly 쿠키로 전달됩니다."
+                    "Access Token과 Refresh Token은 모두 HttpOnly 쿠키로 전달됩니다."
     )
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(

--- a/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResponse.java
@@ -23,9 +23,6 @@ import lombok.NoArgsConstructor;
 @Schema(description = "로그인 응답")
 public class LoginResponse {
 
-    @Schema(description = "Access Token (JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-    private String accessToken;
-
     @Schema(description = "사용자 ID", example = "testuser001")
     private String userId;
 

--- a/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResult.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/dto/LoginResult.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
  * 로그인 결과 내부 DTO
  *
  * <p>Service와 Controller 간의 데이터 전달용 내부 DTO입니다.</p>
- * <p>API 응답에는 loginResponse만 포함되고, refreshToken은 HttpOnly 쿠키로 전달됩니다.</p>
+ * <p>API 응답에는 loginResponse만 포함되고, accessToken과 refreshToken은 HttpOnly 쿠키로 전달됩니다.</p>
  *
  * @author Build-Up Team
  * @since 1.0
@@ -24,6 +24,11 @@ public class LoginResult {
      * 로그인 응답 (API Body로 전달)
      */
     private LoginResponse loginResponse;
+
+    /**
+     * Access Token (HttpOnly 쿠키로 전달, 평문)
+     */
+    private String accessToken;
 
     /**
      * Refresh Token (HttpOnly 쿠키로 전달, 평문)

--- a/src/main/java/com/concrete/buildup/domain/auth/repository/EmployeeRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/repository/EmployeeRepository.java
@@ -79,11 +79,17 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     /**
      * 전화번호로 근로자 조회 (출퇴근 검증용)
-     * User의 phone으로 근로자를 조회합니다.
+     * User의 phone 또는 Employee의 sub_phone으로 근로자를 조회합니다.
+     * 전화번호 비교 시 하이픈, 공백, 괄호를 제거하여 정규화된 형태로 비교합니다.
      *
-     * @param phone 전화번호 (하이픈 포함 또는 제외)
+     * @param phone 전화번호 (정규화된 형태, 숫자만)
      * @return 근로자 + User (Optional)
      */
-    @Query("SELECT e FROM Employee e JOIN FETCH e.user u WHERE u.phone = :phone")
+    @Query(value = "SELECT e.* FROM employees e " +
+                   "JOIN users u ON e.user_id = u.id " +
+                   "WHERE REPLACE(REPLACE(REPLACE(u.phone, '-', ''), ' ', ''), '(', '') = :phone " +
+                   "   OR REPLACE(REPLACE(REPLACE(IFNULL(e.sub_phone, ''), '-', ''), ' ', ''), '(', '') = :phone " +
+                   "LIMIT 1",
+           nativeQuery = true)
     Optional<Employee> findByPhoneWithUser(@Param("phone") String phone);
 }

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -567,9 +567,8 @@ public class AuthService {
             log.debug("현장 ID 조회 완료: userId={}, siteId={}", user.getUserId(), siteId);
         }
 
-        // 9. Response 생성
+        // 9. Response 생성 (Access Token은 HttpOnly 쿠키로 전달)
         LoginResponse loginResponse = LoginResponse.builder()
-                .accessToken(accessToken)
                 .userId(user.getUserId())
                 .userName(userName)
                 .role(user.getRole().getRoleName())

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -577,9 +577,10 @@ public class AuthService {
                 .siteId(siteId)          // 현장 관리자인 경우만 값이 있음
                 .build();
 
-        // 8. LoginResult 생성 (refreshToken 포함, 평문)
+        // 8. LoginResult 생성 (accessToken, refreshToken 포함, 평문)
         LoginResult result = LoginResult.builder()
                 .loginResponse(loginResponse)
+                .accessToken(accessToken)    // 평문 토큰 (쿠키로 전달용)
                 .refreshToken(refreshToken)  // 평문 토큰 (쿠키로 전달용)
                 .refreshTokenMaxAge(expiration / 1000)  // 초 단위로 변환
                 .build();
@@ -832,9 +833,8 @@ public class AuthService {
             log.debug("현장 ID 조회 완료: userId={}, siteId={}", user.getUserId(), siteId);
         }
 
-        // 12. Response 생성
+        // 12. Response 생성 (Access Token은 HttpOnly 쿠키로 전달)
         LoginResponse loginResponse = LoginResponse.builder()
-                .accessToken(newAccessToken)
                 .userId(user.getUserId())
                 .userName(userName)
                 .role(user.getRole().getRoleName())
@@ -843,9 +843,10 @@ public class AuthService {
                 .siteId(siteId)          // 현장 관리자인 경우만 값이 있음
                 .build();
 
-        // 11. LoginResult 생성 (새로운 refreshToken 포함, 평문)
+        // 11. LoginResult 생성 (accessToken, refreshToken 포함, 평문)
         LoginResult result = LoginResult.builder()
                 .loginResponse(loginResponse)
+                .accessToken(newAccessToken)     // 평문 토큰 (쿠키로 전달용)
                 .refreshToken(newRefreshToken)  // 평문 토큰 (쿠키로 전달용)
                 .refreshTokenMaxAge(expiration / 1000)  // 초 단위로 변환 (rememberMe 반영)
                 .build();

--- a/src/main/java/com/concrete/buildup/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/concrete/buildup/domain/upload/controller/UploadController.java
@@ -288,7 +288,8 @@ public class UploadController {
                                             value = """
                                                     {
                                                       "resourceType": "EMPLOYEE_PROFILE",
-                                                      "fileExtension": "jpg"
+                                                      "fileExtension": "jpg",
+                                                      "employeeId": 22
                                                     }
                                                     """
                                     ),
@@ -297,7 +298,9 @@ public class UploadController {
                                             value = """
                                                     {
                                                       "resourceType": "ATTENDANCE_PROBE",
-                                                      "fileExtension": "jpg"
+                                                      "fileExtension": "jpg",
+                                                      "siteId": 1,
+                                                      "employeeId": 22
                                                     }
                                                     """
                                     )

--- a/src/test/java/com/concrete/buildup/domain/attendance/service/EmployeeFaceServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/attendance/service/EmployeeFaceServiceTest.java
@@ -6,6 +6,7 @@ import com.concrete.buildup.domain.auth.repository.EmployeeRepository;
 import com.concrete.buildup.domain.auth.repository.UserRepository;
 import com.concrete.buildup.domain.upload.service.S3Service;
 import com.concrete.buildup.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +31,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class EmployeeFaceServiceTest {
 
-    @InjectMocks
     private EmployeeFaceService employeeFaceService;
 
     @Mock
@@ -41,6 +41,15 @@ class EmployeeFaceServiceTest {
 
     @Mock
     private S3Service s3Service;
+
+    @BeforeEach
+    void setUp() {
+        employeeFaceService = new EmployeeFaceService(
+            userRepository,
+            employeeRepository,
+            java.util.Optional.of(s3Service)
+        );
+    }
 
     @Test
     @DisplayName("얼굴 이미지 등록 성공 - S3 URL 구성 및 저장")

--- a/src/test/java/com/concrete/buildup/domain/auth/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/concrete/buildup/domain/auth/integration/AuthIntegrationTest.java
@@ -203,18 +203,20 @@ class AuthIntegrationTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.accessToken").exists())
                 .andExpect(jsonPath("$.data.userId").value("employee123"))
                 .andReturn();
 
-        // then: Access Token 추출
-        String responseBody = loginResult.getResponse().getContentAsString();
-        String accessToken = objectMapper.readTree(responseBody)
-                .path("data").path("accessToken").asText();
+        // then: Access Token 쿠키 추출
+        String accessTokenCookie = loginResult.getResponse().getHeaders("Set-Cookie").stream()
+                .filter(cookie -> cookie.contains("accessToken="))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("accessToken cookie not found"));
 
-        // when: 내 정보 조회
+        String accessToken = accessTokenCookie.split("accessToken=")[1].split(";")[0];
+
+        // when: 내 정보 조회 (쿠키 전달)
         mockMvc.perform(get("/v1/auth/me")
-                        .header("Authorization", "Bearer " + accessToken))
+                        .cookie(new jakarta.servlet.http.Cookie("accessToken", accessToken)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -254,18 +256,20 @@ class AuthIntegrationTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.accessToken").exists())
                 .andExpect(jsonPath("$.data.userId").value("manager123"))
                 .andReturn();
 
-        // then: Access Token 추출
-        String responseBody = loginResult.getResponse().getContentAsString();
-        String accessToken = objectMapper.readTree(responseBody)
-                .path("data").path("accessToken").asText();
+        // then: Access Token 쿠키 추출
+        String accessTokenCookie = loginResult.getResponse().getHeaders("Set-Cookie").stream()
+                .filter(cookie -> cookie.contains("accessToken="))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("accessToken cookie not found"));
 
-        // when: 내 정보 조회
+        String accessToken = accessTokenCookie.split("accessToken=")[1].split(";")[0];
+
+        // when: 내 정보 조회 (쿠키 전달)
         mockMvc.perform(get("/v1/auth/me")
-                        .header("Authorization", "Bearer " + accessToken))
+                        .cookie(new jakarta.servlet.http.Cookie("accessToken", accessToken)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -319,7 +323,6 @@ class AuthIntegrationTest {
                         .cookie(new jakarta.servlet.http.Cookie("refreshToken", refreshToken)))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.accessToken").exists());
+                .andExpect(jsonPath("$.success").value(true));
     }
 }

--- a/src/test/java/com/concrete/buildup/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/auth/service/AuthServiceTest.java
@@ -325,7 +325,7 @@ class AuthServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getLoginResponse()).isNotNull();
-        assertThat(result.getLoginResponse().getAccessToken()).isEqualTo("new-access-token");
+        assertThat(result.getAccessToken()).isEqualTo("new-access-token");
         assertThat(result.getLoginResponse().getUserId()).isEqualTo(userId);
         assertThat(result.getLoginResponse().getRole()).isEqualTo("EMPLOYEE");
         assertThat(result.getRefreshToken()).isEqualTo("new-refresh-token");


### PR DESCRIPTION
## Summary
- 전화번호 기반 근로자 조회 개선
- 로그인 응답 보안 강화
- Presigned URL API 문서 개선
- Docker 및 CD 인프라 설정

## Changes

### API 개선
- 전화번호 기반 근로자 조회 시 하이픈 정규화 처리
- User.phone 및 Employee.sub_phone 모두 검색하도록 개선
- 로그인 응답에서 액세스 토큰 필드 제거 (HttpOnly 쿠키로만 전달)

### 문서 개선
- Presigned URL API Swagger 예제에 employeeId, siteId 추가
- EMPLOYEE_PROFILE 및 ATTENDANCE_PROBE 타입 예제 보완

### 인프라
- Docker 네트워크를 통한 MySQL-App 컨테이너 연결
- Flyway baseline 설정 추가
- GitHub Actions CD 워크플로우 추가

### 테스트
- 출퇴근/얼굴 인식 테스트 데이터 추가
- 테스트 코드 수정 및 S3 Mock 설정 보완

## Test Plan
- [x] 로그인 후 응답에 accessToken 필드가 없는지 확인
- [x] 전화번호로 근로자 조회 성공 확인 (하이픈 포함/제외 모두)
- [x] Presigned URL 발급 시 employeeId 파라미터 동작 확인
- [x] 얼굴 이미지 등록 E2E 테스트 완료
- [ ] 모든 테스트 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 전화번호 조회 개선: 하이픈·공백·괄호 제거 등 정규화 적용 및 추가 조회 경로 반영

* **문서화**
  * 로그인·토큰 관련 문서 및 예시 업데이트: 액세스 토큰과 리프레시 토큰이 모두 HttpOnly 쿠키로 전달됨을 명시
  * 업로드 API 예시(EMPLOYEE_PROFILE, ATTENDANCE_PROBE)에 식별자 필드 추가

* **변경**
  * 로그인/토큰 갱신 흐름: 액세스 토큰이 응답 본문에 포함되지 않고 쿠키로만 전달되도록 변경

* **테스트**
  * 인증 관련 통합·단위 테스트가 쿠키 기반 토큰 전달을 반영하도록 갱신됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->