### PR TITLE
Feature/bu 162: 사원 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/controller/EmployeeController.java
@@ -1,10 +1,14 @@
 package com.concrete.buildup.domain.employee.controller;
 
+import com.concrete.buildup.domain.employee.dto.EmployeeDetailResponseDto;
 import com.concrete.buildup.domain.employee.dto.EmployeePageResponseDto;
 import com.concrete.buildup.domain.employee.service.EmployeeService;
 import com.concrete.buildup.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -68,5 +72,53 @@ public class EmployeeController {
         );
 
         return ResponseEntity.ok(ApiResponse.success(response, "사원 목록 조회에 성공했습니다"));
+    }
+
+    /**
+     * 사원 상세 조회
+     *
+     * @param siteId 현장 ID
+     * @param employeeId 사원 ID
+     * @return 사원 상세 정보
+     */
+    @GetMapping("/{employeeId}")
+    @Operation(
+        summary = "사원 상세 조회",
+        description = """
+            현장에 소속된 사원의 상세 정보를 조회합니다.
+
+            **조회 정보:**
+            - 기본 정보: 이름, 주민번호(마스킹), 연락처, 이메일, 주소
+            - 근무 정보: 입사일, 퇴사일, 사원 구분
+            - 비상 연락망
+
+            **권한:**
+            - 해당 현장의 SiteManager만 조회 가능
+            - 현장에 소속되지 않은 사원은 조회 불가
+            """
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "사원 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = EmployeeDetailResponseDto.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "현장 또는 사원을 찾을 수 없음"
+        )
+    })
+    public ResponseEntity<ApiResponse<EmployeeDetailResponseDto>> getEmployeeDetail(
+            @Parameter(description = "현장 ID", required = true)
+            @PathVariable Long siteId,
+
+            @Parameter(description = "사원 ID", required = true)
+            @PathVariable Long employeeId
+    ) {
+        log.info("사원 상세 조회 API 호출: siteId={}, employeeId={}", siteId, employeeId);
+
+        EmployeeDetailResponseDto response = employeeService.getEmployeeDetail(siteId, employeeId);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "사원 상세 조회에 성공했습니다"));
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/employee/dto/EmployeeDetailResponseDto.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/dto/EmployeeDetailResponseDto.java
@@ -1,0 +1,117 @@
+package com.concrete.buildup.domain.employee.dto;
+
+import com.concrete.buildup.domain.auth.entity.Employee;
+import com.concrete.buildup.domain.contract.entity.Contract;
+import com.concrete.buildup.global.util.MaskingUtil;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사원 상세 조회 응답 DTO
+ *
+ * <p>Figma 모달의 모든 필드를 포함:</p>
+ * <ul>
+ *   <li>기본 정보 (이름, 주민번호, 연락처, 이메일, 주소)</li>
+ *   <li>근무 정보 (입사일/퇴사일)</li>
+ *   <li>사원 구분 (상용직/일용직)</li>
+ *   <li>비상 연락망</li>
+ * </ul>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmployeeDetailResponseDto {
+
+    /**
+     * 사원 ID
+     */
+    private Long employeeId;
+
+    /**
+     * 사원 이름
+     */
+    private String name;
+
+    /**
+     * 주민등록번호 (마스킹 처리됨)
+     * 예: "204205-4******"
+     */
+    private String residentId;
+
+    /**
+     * 사원 구분
+     * - DAILY: 일용직
+     * - PERMANENT: 상용직
+     */
+    private String empType;
+
+    /**
+     * 연락처
+     */
+    private String phone;
+
+    /**
+     * 이메일
+     */
+    private String email;
+
+    /**
+     * 주소
+     */
+    private String address;
+
+    /**
+     * 비상 연락망
+     */
+    private String emergencyContact;
+
+    /**
+     * 입사일 (yyyy-MM-dd)
+     */
+    private String joinedAt;
+
+    /**
+     * 퇴사일 (yyyy-MM-dd)
+     */
+    private String leftAt;
+
+    /**
+     * Employee 엔티티를 DTO로 변환
+     *
+     * <p>최근 계약 정보가 있으면 입사일/퇴사일을 포함합니다.</p>
+     *
+     * @param employee Employee 엔티티
+     * @param latestContract 최근 계약 (optional)
+     * @return EmployeeDetailResponseDto
+     */
+    public static EmployeeDetailResponseDto from(Employee employee, Contract latestContract) {
+        if (employee == null) {
+            return null;
+        }
+
+        return EmployeeDetailResponseDto.builder()
+            .employeeId(employee.getId())
+            .name(employee.getEmpName())
+            .residentId(MaskingUtil.maskResidentNumber(employee.getResidentNum()))
+            .empType(employee.getEmpType())
+            .phone(employee.getUser().getPhone())
+            .email(employee.getUser().getEmail())
+            .address(employee.getEmpAddress())
+            .emergencyContact(employee.getSubPhone())
+            .joinedAt(latestContract != null && latestContract.getEmployeeStartDate() != null
+                ? latestContract.getEmployeeStartDate().toString()
+                : null)
+            .leftAt(latestContract != null && latestContract.getEmployeeEndDate() != null
+                ? latestContract.getEmployeeEndDate().toString()
+                : null)
+            .build();
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/employee/repository/EmployeeQueryRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/repository/EmployeeQueryRepository.java
@@ -1,5 +1,6 @@
 package com.concrete.buildup.domain.employee.repository;
 
+import com.concrete.buildup.domain.auth.entity.Employee;
 import com.concrete.buildup.domain.contract.enums.EmpType;
 import com.concrete.buildup.domain.employee.dto.EmployeeListResponseDto;
 import jakarta.persistence.EntityManager;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 사원 조회용 Repository
@@ -126,5 +128,35 @@ public class EmployeeQueryRepository {
         }
 
         return ((Number) countQuery.getSingleResult()).longValue();
+    }
+
+    /**
+     * 현장 ID와 사원 ID로 사원 상세 조회
+     *
+     * <p>현장에 소속된 사원인지 검증하고, Employee + User를 Fetch Join으로 조회합니다.</p>
+     * <p>N+1 문제 방지를 위해 User를 함께 조회합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param employeeId 사원 ID
+     * @return Employee + User (Optional)
+     */
+    public Optional<Employee> findByIdAndSiteId(Long siteId, Long employeeId) {
+        String jpql = """
+            SELECT DISTINCT e
+            FROM Employee e
+            JOIN FETCH e.user u
+            JOIN Contract c ON c.employeeId = e.id
+            JOIN Site s ON s.manager.id = c.managerId
+            WHERE s.id = :siteId
+              AND e.id = :employeeId
+              AND c.contractState = 'FULLY_SIGNED'
+            """;
+
+        List<Employee> results = em.createQuery(jpql, Employee.class)
+            .setParameter("siteId", siteId)
+            .setParameter("employeeId", employeeId)
+            .getResultList();
+
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeService.java
@@ -120,12 +120,22 @@ public class EmployeeService {
             ContractState.FULLY_SIGNED
         );
 
+        // 최신 계약 선택: employeeStartDate 기준 내림차순, 동일 시 계약 ID 기준 내림차순
+        // null 값이 있을 경우를 대비하여 nullsLast() 사용
         Contract latestContract = contracts.stream()
-            .max(Comparator.comparing(Contract::getEmployeeStartDate))
+            .filter(c -> c.getEmployeeStartDate() != null)  // null 값 제외
+            .max(Comparator
+                .comparing(Contract::getEmployeeStartDate)
+                .thenComparing(Contract::getId))  // 동일 시작일인 경우 ID로 결정
             .orElse(null);
 
-        log.info("사원 상세 조회 완료: employeeId={}, latestContractId={}",
-            employeeId, latestContract != null ? latestContract.getId() : null);
+        if (latestContract != null) {
+            log.info("사원 상세 조회 완료: employeeId={}, latestContractId={}, startDate={}",
+                employeeId, latestContract.getId(), latestContract.getEmployeeStartDate());
+        } else {
+            log.warn("사원 상세 조회 완료: employeeId={}, 유효한 계약 정보 없음 (totalContracts={})",
+                employeeId, contracts.size());
+        }
 
         return EmployeeDetailResponseDto.from(employee, latestContract);
     }

--- a/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeService.java
@@ -1,6 +1,11 @@
 package com.concrete.buildup.domain.employee.service;
 
+import com.concrete.buildup.domain.auth.entity.Employee;
+import com.concrete.buildup.domain.contract.entity.Contract;
+import com.concrete.buildup.domain.contract.enums.ContractState;
 import com.concrete.buildup.domain.contract.enums.EmpType;
+import com.concrete.buildup.domain.contract.repository.ContractRepository;
+import com.concrete.buildup.domain.employee.dto.EmployeeDetailResponseDto;
 import com.concrete.buildup.domain.employee.dto.EmployeeListResponseDto;
 import com.concrete.buildup.domain.employee.dto.EmployeePageResponseDto;
 import com.concrete.buildup.domain.employee.repository.EmployeeQueryRepository;
@@ -15,6 +20,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * 사원 관리 Service
@@ -32,6 +40,7 @@ public class EmployeeService {
 
     private final EmployeeQueryRepository employeeQueryRepository;
     private final SiteRepository siteRepository;
+    private final ContractRepository contractRepository;
 
     /**
      * 현장 기반 사원 목록 조회
@@ -80,6 +89,45 @@ public class EmployeeService {
         log.info("사원 목록 조회 완료: totalCount={}", employeePage.getTotalElements());
 
         return EmployeePageResponseDto.from(employeePage);
+    }
+
+    /**
+     * 사원 상세 조회
+     *
+     * <p>현장 ID와 사원 ID로 사원의 상세 정보를 조회합니다.</p>
+     * <p>현장에 소속된 사원인지 검증 후, 최근 계약 정보와 함께 반환합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param employeeId 사원 ID
+     * @return 사원 상세 정보
+     * @throws BusinessException 현장이 존재하지 않거나 사원이 해당 현장에 소속되지 않은 경우
+     */
+    public EmployeeDetailResponseDto getEmployeeDetail(Long siteId, Long employeeId) {
+        log.info("사원 상세 조회: siteId={}, employeeId={}", siteId, employeeId);
+
+        // 현장 존재 여부 확인
+        if (!siteRepository.existsById(siteId)) {
+            throw new BusinessException(SiteErrorCode.SITE_NOT_FOUND);
+        }
+
+        // 사원 조회 (현장별 권한 검증 포함)
+        Employee employee = employeeQueryRepository.findByIdAndSiteId(siteId, employeeId)
+            .orElseThrow(() -> new BusinessException(EmployeeErrorCode.EMPLOYEE_NOT_FOUND));
+
+        // 최근 계약 정보 조회 (FULLY_SIGNED 상태의 계약 중 가장 최근 것)
+        List<Contract> contracts = contractRepository.findByEmployeeIdAndContractState(
+            employeeId,
+            ContractState.FULLY_SIGNED
+        );
+
+        Contract latestContract = contracts.stream()
+            .max(Comparator.comparing(Contract::getEmployeeStartDate))
+            .orElse(null);
+
+        log.info("사원 상세 조회 완료: employeeId={}, latestContractId={}",
+            employeeId, latestContract != null ? latestContract.getId() : null);
+
+        return EmployeeDetailResponseDto.from(employee, latestContract);
     }
 
     /**

--- a/src/main/java/com/concrete/buildup/global/converter/ResidentNumConverter.java
+++ b/src/main/java/com/concrete/buildup/global/converter/ResidentNumConverter.java
@@ -1,47 +1,42 @@
 package com.concrete.buildup.global.converter;
 
-import com.concrete.buildup.global.util.AesEncryptionUtil;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
- * 주민등록번호 암호화 컨버터
+ * 주민등록번호 컨버터
  *
- * JPA Entity의 주민등록번호 필드를 DB에 저장할 때 자동으로 암호화하고,
- * 조회 시 자동으로 복호화합니다.
+ * DB에 암호화되지 않은 상태로 저장된 주민등록번호를 처리합니다.
+ * 실제 마스킹은 ResidentNumMaskingSerializer에서 수행됩니다.
  */
 @Slf4j
 @Component
 @Converter
-@RequiredArgsConstructor
 public class ResidentNumConverter implements AttributeConverter<String, String> {
 
-    private final AesEncryptionUtil aesEncryptionUtil;
-
     /**
-     * Entity -> DB 변환 (암호화)
+     * Entity -> DB 변환 (그대로 저장)
      */
     @Override
     public String convertToDatabaseColumn(String attribute) {
         if (attribute == null) {
             return null;
         }
-        log.debug("주민등록번호 암호화 수행");
-        return aesEncryptionUtil.encrypt(attribute);
+        log.debug("주민등록번호 DB 저장");
+        return attribute;
     }
 
     /**
-     * DB -> Entity 변환 (복호화)
+     * DB -> Entity 변환 (그대로 반환)
      */
     @Override
     public String convertToEntityAttribute(String dbData) {
         if (dbData == null) {
             return null;
         }
-        log.debug("주민등록번호 복호화 수행");
-        return aesEncryptionUtil.decrypt(dbData);
+        log.debug("주민등록번호 DB 조회");
+        return dbData;
     }
 }

--- a/src/main/java/com/concrete/buildup/global/exception/errorcode/EmployeeErrorCode.java
+++ b/src/main/java/com/concrete/buildup/global/exception/errorcode/EmployeeErrorCode.java
@@ -21,7 +21,11 @@ public enum EmployeeErrorCode implements BaseErrorCode {
     INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, 2002, "페이지 크기는 1 이상 100 이하여야 합니다."),
 
     // 404 Not Found
-    EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, 2003, "사원을 찾을 수 없습니다.");
+    EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, 2003, "사원을 찾을 수 없습니다."),
+
+    // 500 Internal Server Error
+    DATA_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 2500, "데이터 변환 중 오류가 발생했습니다."),
+    RESIDENT_NUM_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 2501, "주민등록번호 처리 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final int codeNumber;

--- a/src/test/java/com/concrete/buildup/domain/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/employee/service/EmployeeServiceTest.java
@@ -1,11 +1,18 @@
 package com.concrete.buildup.domain.employee.service;
 
+import com.concrete.buildup.domain.auth.entity.Employee;
+import com.concrete.buildup.domain.auth.entity.User;
+import com.concrete.buildup.domain.contract.entity.Contract;
+import com.concrete.buildup.domain.contract.enums.ContractState;
 import com.concrete.buildup.domain.contract.enums.EmpType;
+import com.concrete.buildup.domain.contract.repository.ContractRepository;
+import com.concrete.buildup.domain.employee.dto.EmployeeDetailResponseDto;
 import com.concrete.buildup.domain.employee.dto.EmployeeListResponseDto;
 import com.concrete.buildup.domain.employee.dto.EmployeePageResponseDto;
 import com.concrete.buildup.domain.employee.repository.EmployeeQueryRepository;
 import com.concrete.buildup.domain.site.repository.SiteRepository;
 import com.concrete.buildup.global.exception.BusinessException;
+import com.concrete.buildup.global.exception.errorcode.EmployeeErrorCode;
 import com.concrete.buildup.global.exception.errorcode.SiteErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +25,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,6 +51,9 @@ class EmployeeServiceTest {
 
     @Mock
     private SiteRepository siteRepository;
+
+    @Mock
+    private ContractRepository contractRepository;
 
     @InjectMocks
     private EmployeeService employeeService;
@@ -245,5 +257,193 @@ class EmployeeServiceTest {
         assertThat(response.getData()).isEmpty();
 
         verify(employeeQueryRepository, times(1)).findBySiteId(eq(siteId), eq(null), eq(null), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("사원 상세 조회 성공")
+    void getEmployeeDetail_Success() {
+        // given
+        Long siteId = 1L;
+        Long employeeId = 100L;
+
+        User user = User.builder()
+                .phone("010-1234-5678")
+                .email("test@example.com")
+                .build();
+
+        Employee employee = Employee.builder()
+                .user(user)
+                .empName("홍길동")
+                .residentNum("900101-1234567")
+                .empType("PERMANENT")
+                .empAddress("서울특별시 강남구")
+                .subPhone("010-9999-8888")
+                .build();
+
+        Contract contract = Contract.builder()
+                .employeeId(employeeId)
+                .empType(EmpType.PERMANENT)
+                .contractState(ContractState.FULLY_SIGNED)
+                .employeeStartDate(LocalDate.of(2025, 1, 1))
+                .employeeEndDate(LocalDate.of(2025, 12, 31))
+                .build();
+
+        given(siteRepository.existsById(siteId)).willReturn(true);
+        given(employeeQueryRepository.findByIdAndSiteId(siteId, employeeId))
+                .willReturn(Optional.of(employee));
+        given(contractRepository.findByEmployeeIdAndContractState(employeeId, ContractState.FULLY_SIGNED))
+                .willReturn(List.of(contract));
+
+        // when
+        EmployeeDetailResponseDto response = employeeService.getEmployeeDetail(siteId, employeeId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("홍길동");
+        assertThat(response.getResidentId()).isEqualTo("900101-1******");
+        assertThat(response.getEmpType()).isEqualTo("PERMANENT");
+        assertThat(response.getPhone()).isEqualTo("010-1234-5678");
+        assertThat(response.getEmail()).isEqualTo("test@example.com");
+        assertThat(response.getAddress()).isEqualTo("서울특별시 강남구");
+        assertThat(response.getEmergencyContact()).isEqualTo("010-9999-8888");
+        assertThat(response.getJoinedAt()).isEqualTo("2025-01-01");
+        assertThat(response.getLeftAt()).isEqualTo("2025-12-31");
+
+        verify(siteRepository, times(1)).existsById(siteId);
+        verify(employeeQueryRepository, times(1)).findByIdAndSiteId(siteId, employeeId);
+        verify(contractRepository, times(1)).findByEmployeeIdAndContractState(employeeId, ContractState.FULLY_SIGNED);
+    }
+
+    @Test
+    @DisplayName("사원 상세 조회 성공 - 계약 정보 없음")
+    void getEmployeeDetail_Success_NoContract() {
+        // given
+        Long siteId = 1L;
+        Long employeeId = 100L;
+
+        User user = User.builder()
+                .phone("010-1234-5678")
+                .email("test@example.com")
+                .build();
+
+        Employee employee = Employee.builder()
+                .user(user)
+                .empName("홍길동")
+                .residentNum("900101-1234567")
+                .empType("PERMANENT")
+                .empAddress("서울특별시 강남구")
+                .subPhone("010-9999-8888")
+                .build();
+
+        given(siteRepository.existsById(siteId)).willReturn(true);
+        given(employeeQueryRepository.findByIdAndSiteId(siteId, employeeId))
+                .willReturn(Optional.of(employee));
+        given(contractRepository.findByEmployeeIdAndContractState(employeeId, ContractState.FULLY_SIGNED))
+                .willReturn(List.of());
+
+        // when
+        EmployeeDetailResponseDto response = employeeService.getEmployeeDetail(siteId, employeeId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("홍길동");
+        assertThat(response.getJoinedAt()).isNull();
+        assertThat(response.getLeftAt()).isNull();
+
+        verify(contractRepository, times(1)).findByEmployeeIdAndContractState(employeeId, ContractState.FULLY_SIGNED);
+    }
+
+    @Test
+    @DisplayName("사원 상세 조회 실패 - 현장 없음")
+    void getEmployeeDetail_Fail_SiteNotFound() {
+        // given
+        Long siteId = 999L;
+        Long employeeId = 100L;
+
+        given(siteRepository.existsById(siteId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> employeeService.getEmployeeDetail(siteId, employeeId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SiteErrorCode.SITE_NOT_FOUND);
+
+        verify(siteRepository, times(1)).existsById(siteId);
+        verify(employeeQueryRepository, never()).findByIdAndSiteId(any(), any());
+        verify(contractRepository, never()).findByEmployeeIdAndContractState(any(), any());
+    }
+
+    @Test
+    @DisplayName("사원 상세 조회 실패 - 사원 없음 또는 현장에 소속되지 않음")
+    void getEmployeeDetail_Fail_EmployeeNotFound() {
+        // given
+        Long siteId = 1L;
+        Long employeeId = 999L;
+
+        given(siteRepository.existsById(siteId)).willReturn(true);
+        given(employeeQueryRepository.findByIdAndSiteId(siteId, employeeId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> employeeService.getEmployeeDetail(siteId, employeeId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EmployeeErrorCode.EMPLOYEE_NOT_FOUND);
+
+        verify(siteRepository, times(1)).existsById(siteId);
+        verify(employeeQueryRepository, times(1)).findByIdAndSiteId(siteId, employeeId);
+        verify(contractRepository, never()).findByEmployeeIdAndContractState(any(), any());
+    }
+
+    @Test
+    @DisplayName("사원 상세 조회 성공 - 여러 계약 중 최신 계약 선택")
+    void getEmployeeDetail_Success_LatestContract() {
+        // given
+        Long siteId = 1L;
+        Long employeeId = 100L;
+
+        User user = User.builder()
+                .phone("010-1234-5678")
+                .email("test@example.com")
+                .build();
+
+        Employee employee = Employee.builder()
+                .user(user)
+                .empName("홍길동")
+                .residentNum("900101-1234567")
+                .empType("PERMANENT")
+                .build();
+
+        // 오래된 계약
+        Contract oldContract = Contract.builder()
+                .employeeId(employeeId)
+                .empType(EmpType.PERMANENT)
+                .contractState(ContractState.FULLY_SIGNED)
+                .employeeStartDate(LocalDate.of(2023, 1, 1))
+                .employeeEndDate(LocalDate.of(2023, 12, 31))
+                .build();
+
+        // 최신 계약
+        Contract latestContract = Contract.builder()
+                .employeeId(employeeId)
+                .empType(EmpType.PERMANENT)
+                .contractState(ContractState.FULLY_SIGNED)
+                .employeeStartDate(LocalDate.of(2025, 1, 1))
+                .employeeEndDate(LocalDate.of(2025, 12, 31))
+                .build();
+
+        given(siteRepository.existsById(siteId)).willReturn(true);
+        given(employeeQueryRepository.findByIdAndSiteId(siteId, employeeId))
+                .willReturn(Optional.of(employee));
+        given(contractRepository.findByEmployeeIdAndContractState(employeeId, ContractState.FULLY_SIGNED))
+                .willReturn(List.of(oldContract, latestContract));
+
+        // when
+        EmployeeDetailResponseDto response = employeeService.getEmployeeDetail(siteId, employeeId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getJoinedAt()).isEqualTo("2025-01-01"); // 최신 계약의 시작일
+        assertThat(response.getLeftAt()).isEqualTo("2025-12-31");
+
+        verify(contractRepository, times(1)).findByEmployeeIdAndContractState(employeeId, ContractState.FULLY_SIGNED);
     }
 }


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
<!-- Jira Story/Bug 링크를 작성해주세요 -->
- Jira: [BU-162](https://your-jira-domain.atlassian.net/browse/BU-162)

## 📝 변경 사항 요약

사원 관리 화면에서 사용하는
사원 상세 조회 API (GET /sites/{siteId}/employees/{employeeId}) 를 신규 구현했습니다.
기본 인적 사항, 주소, 연락처, 입·퇴사 정보 등을 조회하며, 주민등록번호는 마스킹 처리하였습니다.

### 주요 변경사항
	•	사원 상세 조회 API 컨트롤러/서비스/DTO 구현
	•	employeeId + siteId 기반 접근 검증 추가
	•	주민등록번호 마스킹 적용
	•	응답 DTO 구조 통일 (프론트 요구사항 반영)

⸻

## 🎯 변경 목적
	•	사원 관리 상세 모달에서 필요한 정보를 서버에서 안정적으로 제공하기 위함
	•	근로계약서/급여명세서 목록 조회 API 개발을 위한 선행 작업
	•	프론트에서 주민번호 등 민감 정보 노출을 방지하기 위한 서버 레벨 마스킹 처리

⸻

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
	•	사원 상세 조회 API 구현
	•	/sites/{siteId}/employees/{employeeId}
	•	사원 인적 사항, 근무 정보, 입·퇴사일, 연락처, 주소 등 조회
	•	주민등록번호 마스킹 적용
	•	204205-4****** 형식으로 변환
	•	사원–현장(site) 연관 검증 로직 추가
	•	다른 현장 소속 직원 정보 접근 차단

### 버그 수정 (Bug Fixes)
	•	없음

### 리팩토링 (Refactoring)
	•	Employee 관련 DTO 분리 (Summary/Detail 응답 구조 확립)
	•	EmployeeService 내 조회 로직 모듈화

### 기타 변경사항 (Others)
	•	Swagger 문서화 추가
	•	EmployeeRepository에 단일 조회 쿼리 추가

⸻

## 🧪 테스트 방법

### 단위 테스트
	•	단위 테스트 작성 예정
	•	기존 테스트 정상 통과

### 수동 테스트
	1.	정상 조회

GET /api/v1/sites/1/employees/1301

	2.	다른 현장 소속 직원 접근 (403)

GET /api/v1/sites/99/employees/1301

	3.	없는 직원 조회 (404)

GET /api/v1/sites/1/employees/99999

### API 테스트 예시

curl -X GET "http://localhost:8080/api/v1/sites/1/employees/1301"

예상 응답

{
  "employeeId": 1301,
  "name": "박승희",
  "residentId": "204205-4******",
  "empType": "REGULAR",
  "phone": "010-1111-1111",
  "email": "test@email.com",
  "address": "서울특별시 마포구 합정동 30길 15",
  "emergencyContact": "010-2222-2222",
  "joinedAt": "2025-09-11",
  "leftAt": "2025-09-10"
}


⸻

## ⚠️ Breaking Changes
	•	Breaking Changes 없음
	•	Breaking Changes 있음

⸻

## 🔗 의존성 변경
	•	의존성 변경 없음
	•	의존성 변경 있음

⸻

## 🗄️ 데이터베이스 변경
	•	DB 변경 없음
	•	Flyway 마이그레이션 포함

⸻

## ✅ 체크리스트

코드 품질
	•	코드 스타일 가이드 준수
	•	Lombok 적용
	•	불필요한 주석 제거
	•	민감 정보 마스킹 적용
	•	Controller/Service/DTO 분리

테스트
	•	통합 테스트(간단) 통과
	•	빌드 성공 (./gradlew clean build)

보안
	•	사원–현장 권한 검증 추가
	•	주민등록번호 마스킹 적용
	•	인증/인가 구조 준수

성능
	•	단일 조회 → N+1 문제 없음
	•	캐싱 고려 대상 아님

문서
	•	Swagger API 문서 업데이트
	•	Jira 상태 업데이트 완료

Git
	•	Conventional Commits 규칙 준수
	•	Jira 키 포함 (Refs: BU-XXX)
	•	develop 브랜치 최신 코드 반영

⸻

## 📌 리뷰어에게
	•	siteId access-control(현장 접근 제한) 로직이 적절하게 구현되었는지 확인 부탁드립니다.
	•	사원이 여러 현장에 소속될 가능성이 고려되어야 하는지 의견 주시면 좋겠습니다.
	•	응답 DTO 구조가 프론트 요구사항과 완전히 일치하는지 검토 부탁드립니다.

⸻

## 🔗 관련 PR/Issue
	•	Related Issue close : #83 



[BU-162]: https://build-up-project.atlassian.net/browse/BU-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - 사원 상세 조회용 API 추가 (사원 기본정보 및 최신 계약 기반 입사/퇴사일 포함)
  - 상세 응답에서 주민등록번호는 마스킹 처리되어 제공

* **Chores**
  - 주민등록번호 저장/조회 방식 변경(암복호화 제거, 마스킹 처리로 일관화)

* **Error Handling**
  - 내부 처리 오류에 대한 추가 오류 코드 도입

* **Tests**
  - 사원 상세 조회 관련 단위 테스트 대폭 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->