### PR TITLE
feature/BU-181: 작업일보 PDF 미리보기/다운로드 API 추가

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/concrete/buildup/domain/document/controller/DocumentController.java
@@ -164,4 +164,47 @@ public class DocumentController {
 
         return ResponseEntity.ok(ApiResponse.success(response, "급여명세서 PDF URL 발급에 성공했습니다"));
     }
+
+    /**
+     * 작업일보 PDF Signed URL 조회
+     *
+     * @param workReportId 작업일보 ID
+     * @return Signed URL 응답
+     */
+    @GetMapping("/work-reports/{workReportId}")
+    @Operation(
+        summary = "작업일보 PDF 조회 (미리보기/다운로드)",
+        description = """
+            작업일보 PDF 파일을 조회하기 위한 Signed URL을 발급합니다.
+
+            **사용 방법:**
+            - 발급된 URL을 iframe 또는 PDF 뷰어에서 사용 (미리보기)
+            - 발급된 URL로 직접 다운로드 가능
+            - URL은 15분 후 만료됩니다.
+
+            **S3 경로:**
+            - work-reports/{siteId}/{date}/WR-{workReportId}.pdf
+            """
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "Signed URL 발급 성공",
+            content = @Content(schema = @Schema(implementation = DocumentUrlResponseDto.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "작업일보 또는 문서를 찾을 수 없음"
+        )
+    })
+    public ResponseEntity<ApiResponse<DocumentUrlResponseDto>> getWorkReportPdf(
+            @Parameter(description = "작업일보 ID", required = true)
+            @PathVariable Long workReportId
+    ) {
+        log.info("작업일보 PDF 조회 API 호출: workReportId={}", workReportId);
+
+        DocumentUrlResponseDto response = documentService.getWorkReportPdfUrl(workReportId);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "작업일보 PDF URL 발급에 성공했습니다"));
+    }
 }

--- a/src/main/java/com/concrete/buildup/domain/document/service/DocumentService.java
+++ b/src/main/java/com/concrete/buildup/domain/document/service/DocumentService.java
@@ -12,6 +12,8 @@ import com.concrete.buildup.domain.safetydoc.entity.SafetyEducationLog;
 import com.concrete.buildup.domain.safetydoc.enums.SafetyEducationStatus;
 import com.concrete.buildup.domain.safetydoc.repository.SafetyEducationLogRepository;
 import com.concrete.buildup.domain.upload.service.S3Service;
+import com.concrete.buildup.domain.workreport.entity.WorkReport;
+import com.concrete.buildup.domain.workreport.repository.WorkReportRepository;
 import com.concrete.buildup.global.exception.BusinessException;
 import com.concrete.buildup.global.exception.errorcode.CommonErrorCode;
 import com.concrete.buildup.global.exception.errorcode.DocumentErrorCode;
@@ -40,6 +42,7 @@ public class DocumentService {
     private final ContractDetailRepository contractDetailRepository;
     private final PayrollRepository payrollRepository;
     private final SafetyEducationLogRepository safetyEducationLogRepository;
+    private final WorkReportRepository workReportRepository;
 
     private static final int SIGNED_URL_EXPIRATION_MINUTES = 15;
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -190,6 +193,55 @@ public class DocumentService {
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(SIGNED_URL_EXPIRATION_MINUTES);
 
         log.info("안전교육일지 PDF URL 발급 완료: logId={}, status={}, expiresAt={}", logId, educationLog.getStatus(), expiresAt);
+
+        return DocumentUrlResponseDto.of(signedUrl, expiresAt);
+    }
+
+    /**
+     * 작업일보 PDF Signed URL 발급
+     *
+     * <p>작업일보의 pdfUrl을 사용하여 Signed URL을 발급합니다.</p>
+     *
+     * @param workReportId 작업일보 ID
+     * @return Signed URL 응답
+     * @throws BusinessException 작업일보가 존재하지 않거나 PDF 파일이 없는 경우
+     */
+    public DocumentUrlResponseDto getWorkReportPdfUrl(Long workReportId) {
+        log.info("작업일보 PDF URL 발급 요청: workReportId={}", workReportId);
+
+        // 작업일보 조회
+        WorkReport workReport = workReportRepository.findById(workReportId)
+                .orElseThrow(() -> new BusinessException(DocumentErrorCode.WORK_REPORT_NOT_FOUND));
+
+        // PDF URL 확인
+        String pdfUrl = workReport.getPdfUrl();
+        if (pdfUrl == null || pdfUrl.isBlank()) {
+            log.warn("작업일보 PDF가 아직 생성되지 않음: workReportId={}", workReportId);
+            throw new BusinessException(DocumentErrorCode.DOCUMENT_NOT_FOUND);
+        }
+
+        // S3 서비스 확인
+        S3Service service = s3Service.orElseThrow(() ->
+                new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR, "S3 서비스가 비활성화되어 있습니다."));
+
+        // S3 키 추출
+        String s3Key = service.extractS3KeyFromUrl(pdfUrl);
+        if (s3Key == null || s3Key.isBlank()) {
+            log.warn("작업일보 PDF URL에서 S3 키 추출 실패: workReportId={}, pdfUrl={}", workReportId, pdfUrl);
+            throw new BusinessException(DocumentErrorCode.DOCUMENT_NOT_FOUND);
+        }
+
+        // S3에 파일 존재 여부 확인
+        if (!service.doesObjectExist(s3Key)) {
+            log.warn("작업일보 PDF 파일이 존재하지 않음: s3Key={}", s3Key);
+            throw new BusinessException(DocumentErrorCode.DOCUMENT_NOT_FOUND);
+        }
+
+        // Signed URL 발급
+        String signedUrl = service.generatePresignedGetUrl(s3Key);
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(SIGNED_URL_EXPIRATION_MINUTES);
+
+        log.info("작업일보 PDF URL 발급 완료: workReportId={}, expiresAt={}", workReportId, expiresAt);
 
         return DocumentUrlResponseDto.of(signedUrl, expiresAt);
     }

--- a/src/main/java/com/concrete/buildup/domain/upload/service/S3Service.java
+++ b/src/main/java/com/concrete/buildup/domain/upload/service/S3Service.java
@@ -512,6 +512,12 @@ public class S3Service {
             return url.substring(contractsIndex);
         }
 
+        // work-reports/ 로 시작하는 키 추출
+        int workReportsIndex = url.indexOf("work-reports/");
+        if (workReportsIndex != -1) {
+            return url.substring(workReportsIndex);
+        }
+
         // uploads/ 로 시작하는 키 추출
         int uploadsIndex = url.indexOf("uploads/");
         if (uploadsIndex != -1) {

--- a/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
@@ -7,6 +7,9 @@ import com.concrete.buildup.global.common.ApiResponse;
 import com.concrete.buildup.global.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -57,11 +60,32 @@ public class WorkReportController {
      */
     @Operation(
             summary = "작업일보 생성",
-            description = "관리자가 작업일보를 생성합니다. " +
-                    "PDF가 즉시 생성되어 S3에 업로드되며, 생성 완료 후 PDF URL이 반환됩니다. " +
-                    "동일 현장의 동일 날짜에 여러 개의 작업일보를 생성할 수 있으며, " +
-                    "생성 순서대로 순번이 부여됩니다 (예: WR-2025-11-23-1.pdf, WR-2025-11-23-2.pdf)."
+            description = """
+                관리자가 작업일보를 생성합니다.
+
+                **처리 과정:**
+                1. 작업일보 DB 저장
+                2. PDF 즉시 생성 및 S3 업로드
+                3. PDF URL 반환
+
+                **파일명 규칙:** `WR-{날짜}-{순번}.pdf` (예: WR-2025-11-24-1.pdf)
+                """
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "작업일보 생성 성공",
+                    content = @Content(schema = @Schema(implementation = CreateWorkReportResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (필수 필드 누락, 유효성 검증 실패)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "현장을 찾을 수 없음"
+            )
+    })
     @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
     @PostMapping
     public ResponseEntity<ApiResponse<CreateWorkReportResponse>> createWorkReport(

--- a/src/main/java/com/concrete/buildup/domain/workreport/dto/CreateWorkReportRequest.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/dto/CreateWorkReportRequest.java
@@ -24,14 +24,17 @@ import java.util.List;
 @Schema(description = "작업일보 생성 요청")
 public class CreateWorkReportRequest {
 
-    @Schema(description = "공정 목록 (여러 공정 입력 가능)")
+    @Schema(
+            description = "공정 목록 (최소 1개 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @Valid
     @NotNull(message = "공정 목록은 필수입니다.")
     @Size(min = 1, message = "최소 1개 이상의 공정이 필요합니다.")
     @Builder.Default
     private List<WorkSectionDto> workSections = new ArrayList<>();
 
-    @Schema(description = "투입 자재 목록")
+    @Schema(description = "투입 자재 목록 (선택)")
     @Valid
     @Builder.Default
     private List<MaterialInputDto> materials = new ArrayList<>();

--- a/src/main/java/com/concrete/buildup/domain/workreport/dto/MaterialInputDto.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/dto/MaterialInputDto.java
@@ -21,16 +21,29 @@ import lombok.NoArgsConstructor;
 @Schema(description = "자재 투입 정보")
 public class MaterialInputDto {
 
-    @Schema(description = "자재 품명", example = "레미콘")
+    @Schema(
+            description = "자재 품명",
+            example = "레미콘",
+            maxLength = 100,
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "자재 품명은 필수입니다.")
     @Size(max = 100, message = "자재 품명은 100자 이하여야 합니다.")
     private String materialName;
 
-    @Schema(description = "자재 규격", example = "25-210-12")
+    @Schema(
+            description = "자재 규격",
+            example = "25-210-12",
+            maxLength = 100
+    )
     @Size(max = 100, message = "자재 규격은 100자 이하여야 합니다.")
     private String materialStandard;
 
-    @Schema(description = "자재 단위", example = "m³")
+    @Schema(
+            description = "자재 단위",
+            example = "m³",
+            maxLength = 20
+    )
     @Size(max = 20, message = "자재 단위는 20자 이하여야 합니다.")
     private String materialUnit;
 }

--- a/src/main/java/com/concrete/buildup/domain/workreport/dto/WorkSectionDto.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/dto/WorkSectionDto.java
@@ -24,25 +24,29 @@ import lombok.NoArgsConstructor;
 @Schema(description = "공정 정보")
 public class WorkSectionDto {
 
-    /**
-     * 공정명 (예: 철근공사, 거푸집공사)
-     */
-    @Schema(description = "공정명", example = "철근공사")
+    @Schema(
+            description = "공정명",
+            example = "철근공사",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "공정명은 필수입니다.")
     private String sectionName;
 
-    /**
-     * 투입 인력 수 (명)
-     */
-    @Schema(description = "투입 인력 수", example = "9")
+    @Schema(
+            description = "투입 인력 수 (명)",
+            example = "9",
+            minimum = "0",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotNull(message = "투입 인력 수는 필수입니다.")
     @Min(value = 0, message = "투입 인력 수는 0 이상이어야 합니다.")
     private Integer employeeNum;
 
-    /**
-     * 공정별 작업 내용
-     */
-    @Schema(description = "작업 내용", example = "1층 바닥 철근 배근 작업 완료")
+    @Schema(
+            description = "작업 내용",
+            example = "1층 바닥 철근 배근 작업 완료",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "작업 내용은 필수입니다.")
     private String context;
 }

--- a/src/main/java/com/concrete/buildup/global/exception/errorcode/DocumentErrorCode.java
+++ b/src/main/java/com/concrete/buildup/global/exception/errorcode/DocumentErrorCode.java
@@ -17,7 +17,8 @@ public enum DocumentErrorCode implements BaseErrorCode {
     CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, 9001, "근로계약서를 찾을 수 없습니다."),
     PAYROLL_NOT_FOUND(HttpStatus.NOT_FOUND, 9002, "급여명세서를 찾을 수 없습니다."),
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, 9003, "문서 파일을 찾을 수 없습니다."),
-    SAFETY_EDUCATION_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, 9004, "안전교육일지를 찾을 수 없습니다.");
+    SAFETY_EDUCATION_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, 9004, "안전교육일지를 찾을 수 없습니다."),
+    WORK_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, 9005, "작업일보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final int codeNumber;

--- a/src/test/java/com/concrete/buildup/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/document/service/DocumentServiceTest.java
@@ -15,6 +15,8 @@ import com.concrete.buildup.domain.safetydoc.enums.EducationType;
 import com.concrete.buildup.domain.safetydoc.enums.SafetyEducationStatus;
 import com.concrete.buildup.domain.safetydoc.repository.SafetyEducationLogRepository;
 import com.concrete.buildup.domain.upload.service.S3Service;
+import com.concrete.buildup.domain.workreport.entity.WorkReport;
+import com.concrete.buildup.domain.workreport.repository.WorkReportRepository;
 import com.concrete.buildup.global.exception.BusinessException;
 import com.concrete.buildup.global.exception.errorcode.DocumentErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -53,6 +55,9 @@ class DocumentServiceTest {
     @Mock
     private SafetyEducationLogRepository safetyEducationLogRepository;
 
+    @Mock
+    private WorkReportRepository workReportRepository;
+
     private DocumentService documentService;
 
     @org.junit.jupiter.api.BeforeEach
@@ -62,7 +67,8 @@ class DocumentServiceTest {
                 contractRepository,
                 contractDetailRepository,
                 payrollRepository,
-                safetyEducationLogRepository
+                safetyEducationLogRepository,
+                workReportRepository
         );
     }
 
@@ -553,6 +559,107 @@ class DocumentServiceTest {
 
             // when & then
             assertThatThrownBy(() -> documentService.getSafetyEducationLogPdfUrl(logId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DocumentErrorCode.DOCUMENT_NOT_FOUND);
+
+            verify(s3Service).extractS3KeyFromUrl(pdfUrl);
+            verify(s3Service).doesObjectExist(expectedS3Key);
+            verify(s3Service, never()).generatePresignedGetUrl(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("작업일보 PDF URL 발급")
+    class GetWorkReportPdfUrl {
+
+        @Test
+        @DisplayName("성공 - PDF URL 존재")
+        void success() {
+            // given
+            Long workReportId = 1L;
+            String expectedS3Key = "work-reports/1/2025-01-24/WR-1.pdf";
+            String pdfUrl = "https://bucket.s3.amazonaws.com/work-reports/1/2025-01-24/WR-1.pdf";
+            String expectedSignedUrl = "https://bucket.s3.amazonaws.com/signed-url";
+
+            WorkReport workReport = WorkReport.builder()
+                    .workSections("[{\"sectionName\":\"철근공사\"}]")
+                    .build();
+            workReport.updatePdf(pdfUrl, LocalDateTime.now());
+
+            given(workReportRepository.findById(workReportId)).willReturn(Optional.of(workReport));
+            given(s3Service.extractS3KeyFromUrl(pdfUrl)).willReturn(expectedS3Key);
+            given(s3Service.doesObjectExist(expectedS3Key)).willReturn(true);
+            given(s3Service.generatePresignedGetUrl(expectedS3Key)).willReturn(expectedSignedUrl);
+
+            // when
+            DocumentUrlResponseDto response = documentService.getWorkReportPdfUrl(workReportId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getUrl()).isEqualTo(expectedSignedUrl);
+            assertThat(response.getExpiresAt()).isNotNull();
+
+            verify(workReportRepository).findById(workReportId);
+            verify(s3Service).extractS3KeyFromUrl(pdfUrl);
+            verify(s3Service).doesObjectExist(expectedS3Key);
+            verify(s3Service).generatePresignedGetUrl(expectedS3Key);
+        }
+
+        @Test
+        @DisplayName("실패 - 작업일보 없음")
+        void fail_workReportNotFound() {
+            // given
+            Long workReportId = 999L;
+            given(workReportRepository.findById(workReportId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> documentService.getWorkReportPdfUrl(workReportId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DocumentErrorCode.WORK_REPORT_NOT_FOUND);
+
+            verify(workReportRepository).findById(workReportId);
+            verify(s3Service, never()).doesObjectExist(anyString());
+        }
+
+        @Test
+        @DisplayName("실패 - PDF URL 없음")
+        void fail_noPdfUrl() {
+            // given
+            Long workReportId = 1L;
+            WorkReport workReport = WorkReport.builder()
+                    .workSections("[{\"sectionName\":\"철근공사\"}]")
+                    .build();
+            // PDF URL이 설정되지 않음
+
+            given(workReportRepository.findById(workReportId)).willReturn(Optional.of(workReport));
+
+            // when & then
+            assertThatThrownBy(() -> documentService.getWorkReportPdfUrl(workReportId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DocumentErrorCode.DOCUMENT_NOT_FOUND);
+
+            verify(s3Service, never()).doesObjectExist(anyString());
+        }
+
+        @Test
+        @DisplayName("실패 - S3 파일 없음")
+        void fail_s3FileNotFound() {
+            // given
+            Long workReportId = 1L;
+            String expectedS3Key = "work-reports/1/2025-01-24/WR-1.pdf";
+            String pdfUrl = "https://bucket.s3.amazonaws.com/work-reports/1/2025-01-24/WR-1.pdf";
+
+            WorkReport workReport = WorkReport.builder()
+                    .workSections("[{\"sectionName\":\"철근공사\"}]")
+                    .build();
+            workReport.updatePdf(pdfUrl, LocalDateTime.now());
+
+            given(workReportRepository.findById(workReportId)).willReturn(Optional.of(workReport));
+            given(s3Service.extractS3KeyFromUrl(pdfUrl)).willReturn(expectedS3Key);
+            given(s3Service.doesObjectExist(expectedS3Key)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> documentService.getWorkReportPdfUrl(workReportId))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", DocumentErrorCode.DOCUMENT_NOT_FOUND);
 


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-181](https://buildupteam.atlassian.net/browse/BU-181)

## 📝 변경 사항 요약
작업일보 PDF를 미리보기하고 다운로드할 수 있는 API를 추가합니다.

### 주요 변경사항
- 작업일보 PDF Signed URL 발급 API 추가 (`GET /documents/work-reports/{workReportId}`)
- DocumentService에 작업일보 PDF URL 발급 로직 구현
- S3Service에 work-reports 경로 지원 추가
- 작업일보 API Swagger 문서 상세화

## 🎯 변경 목적
작업일보 생성 후 사용자가 PDF를 미리보기하거나 다운로드할 수 있도록 하기 위함

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] `GET /documents/work-reports/{workReportId}` - 작업일보 PDF Signed URL 발급 API
- [x] `DocumentService.getWorkReportPdfUrl()` - 작업일보 PDF URL 발급 서비스 메서드
- [x] `DocumentErrorCode.WORK_REPORT_NOT_FOUND` - 작업일보 조회 실패 에러코드
- [x] `S3Service.extractS3KeyFromUrl()` work-reports 경로 지원

### 기타 변경사항 (Others)
- [x] WorkReportController Swagger 문서 상세화 (에러 응답 코드 문서화)
- [x] CreateWorkReportRequest/Response DTO Swagger 문서 개선
- [x] WorkSectionDto, MaterialInputDto 필수/선택 필드 및 제약조건 명시

## 🧪 테스트 방법

### 단위 테스트
- [x] 단위 테스트 작성 완료
- [x] 기존 테스트 통과 확인

### API 테스트 예시
```bash
# 작업일보 PDF URL 조회
curl -X GET http://localhost:8080/api/documents/work-reports/1 \
  -H "Authorization: Bearer {ACCESS_TOKEN}"
```

**예상 결과:**
```json
{
  "success": true,
  "message": "작업일보 PDF URL 발급에 성공했습니다",
  "data": {
    "signedUrl": "https://build-up-contracts.s3.ap-northeast-2.amazonaws.com/work-reports/1/2025-11-24/WR-2025-11-24-1.pdf?X-Amz-...",
    "expiresAt": "2025-11-24T06:15:00"
  }
}
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거
- [x] 로그 레벨 적절히 설정

### 테스트
- [x] 단위 테스트 작성 완료
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토
- [x] 인증/인가 로직 검토
- [x] 입력 검증 로직 추가

### 문서
- [x] API 문서 업데이트 (Swagger 주석)

### Git
- [x] Conventional Commits 규칙 준수
- [x] develop 브랜치 최신 코드 반영

## 📌 리뷰어에게
- 안전교육일지 PDF URL 발급 API와 동일한 패턴으로 구현했습니다
- S3Service.extractS3KeyFromUrl()에 work-reports 경로 지원을 추가했습니다

## 🔗 관련 PR/Issue
- Related PR: #101 (feature/BU-180 안전교육일지)

[BU-181]: https://build-up-project.atlassian.net/browse/BU-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 작업일보 PDF 파일에 대한 서명된 URL 다운로드 기능 추가

* **개선 사항**
  * 작업일보 생성 API의 문서화 및 응답 코드 상세화
  * 작업일보 입력 필드의 필수 항목 및 유효성 검증 강화
  * 작업일보 조회 실패 시 오류 처리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->