### PR TITLE
feature/BU-182: 기업 관리자용 안전/작업 문서 통합 목록 API 추가

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
@@ -7,6 +7,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -39,4 +43,22 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
             LocalDateTime startDateTime,
             LocalDateTime endDateTime
     );
+
+    /**
+     * 현장별 안전교육일지가 있는 날짜 목록 조회 (중복 제거, 페이지네이션)
+     */
+    @Query("SELECT DISTINCT CAST(s.createdAt AS LocalDate) FROM SafetyEducationLog s " +
+            "WHERE s.site.id = :siteId AND s.isDeleted = false " +
+            "ORDER BY CAST(s.createdAt AS LocalDate) DESC")
+    Page<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId, Pageable pageable);
+
+    /**
+     * 현장별, 날짜별 안전교육일지 조회 (가장 최근 것 1개)
+     */
+    @Query("SELECT s FROM SafetyEducationLog s " +
+            "WHERE s.site.id = :siteId " +
+            "AND CAST(s.createdAt AS LocalDate) = :date " +
+            "AND s.isDeleted = false " +
+            "ORDER BY s.createdAt DESC")
+    List<SafetyEducationLog> findBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
@@ -51,11 +51,16 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
 
     /**
      * 현장별, 날짜별 안전교육일지 조회 (가장 최근 것 1개)
+     *
+     * @param siteId 현장 ID
+     * @param date 조회 날짜
+     * @return 해당 날짜의 가장 최근 안전교육일지 (없으면 Optional.empty())
      */
     @Query("SELECT s FROM SafetyEducationLog s " +
             "WHERE s.site.id = :siteId " +
             "AND CAST(s.createdAt AS LocalDate) = :date " +
             "AND s.isDeleted = false " +
-            "ORDER BY s.createdAt DESC")
-    List<SafetyEducationLog> findBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
+            "ORDER BY s.createdAt DESC " +
+            "LIMIT 1")
+    Optional<SafetyEducationLog> findLatestBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
@@ -2,6 +2,7 @@ package com.concrete.buildup.domain.safetydoc.repository;
 
 import com.concrete.buildup.domain.safetydoc.entity.SafetyEducationLog;
 import com.concrete.buildup.domain.safetydoc.enums.SafetyEducationStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -50,17 +51,20 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
     List<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId);
 
     /**
-     * 현장별, 날짜별 안전교육일지 조회 (가장 최근 것 1개)
+     * 현장별, 날짜별 안전교육일지 조회 (페이지네이션 지원)
      *
      * @param siteId 현장 ID
      * @param date 조회 날짜
-     * @return 해당 날짜의 가장 최근 안전교육일지 (없으면 Optional.empty())
+     * @param pageable 페이지네이션 정보
+     * @return 해당 날짜의 안전교육일지 목록 (createdAt 내림차순)
      */
     @Query("SELECT s FROM SafetyEducationLog s " +
             "WHERE s.site.id = :siteId " +
             "AND CAST(s.createdAt AS LocalDate) = :date " +
             "AND s.isDeleted = false " +
-            "ORDER BY s.createdAt DESC " +
-            "LIMIT 1")
-    Optional<SafetyEducationLog> findLatestBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
+            "ORDER BY s.createdAt DESC")
+    List<SafetyEducationLog> findBySiteIdAndDate(
+            @Param("siteId") Long siteId,
+            @Param("date") LocalDate date,
+            Pageable pageable);
 }

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
@@ -7,9 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -45,12 +42,12 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
     );
 
     /**
-     * 현장별 안전교육일지가 있는 날짜 목록 조회 (중복 제거, 페이지네이션)
+     * 현장별 안전교육일지가 있는 날짜 목록 조회 (중복 제거)
      */
     @Query("SELECT DISTINCT CAST(s.createdAt AS LocalDate) FROM SafetyEducationLog s " +
             "WHERE s.site.id = :siteId AND s.isDeleted = false " +
             "ORDER BY CAST(s.createdAt AS LocalDate) DESC")
-    Page<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId, Pageable pageable);
+    List<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId);
 
     /**
      * 현장별, 날짜별 안전교육일지 조회 (가장 최근 것 1개)

--- a/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
+++ b/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
@@ -1,5 +1,6 @@
 package com.concrete.buildup.domain.site.controller;
 
+import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentListResponse;
 import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
 import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
 import com.concrete.buildup.domain.site.dto.SiteDetailResponse;
@@ -8,10 +9,15 @@ import com.concrete.buildup.global.common.ApiResponse;
 import com.concrete.buildup.global.util.MaskingUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -97,6 +103,96 @@ public class SiteController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(response, "현장 정보를 성공적으로 조회했습니다")
+        );
+    }
+
+    /**
+     * 안전/작업 문서 목록 조회 API (기업 관리자용)
+     *
+     * <p>현장의 안전교육일지와 작업일보를 날짜별로 통합 조회합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param pageable 페이지네이션 정보 (기본값: page=0, size=20)
+     * @return SafetyWorkDocumentListResponse - 날짜별 문서 목록
+     */
+    @Operation(
+            summary = "안전/작업 문서 목록 조회 (기업 관리자용)",
+            description = """
+                    현장의 안전교육일지와 작업일보를 날짜별로 통합 조회합니다.
+
+                    **조회 정보:**
+                    - 날짜별 안전교육일지 (ID, 상태, 교육과목)
+                    - 날짜별 작업일보 (ID, 순번)
+
+                    **정렬:** 최신 날짜순 (내림차순)
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "message": "안전/작업 문서 목록을 조회했습니다.",
+                                      "data": {
+                                        "content": [
+                                          {
+                                            "date": "2025-11-24",
+                                            "safetyEducationLog": {
+                                              "logId": 15,
+                                              "status": "COMPLETED",
+                                              "educationSubject": "추락 재해 예방 교육"
+                                            },
+                                            "workReport": {
+                                              "workReportId": 23,
+                                              "sequence": 1
+                                            }
+                                          },
+                                          {
+                                            "date": "2025-11-23",
+                                            "safetyEducationLog": null,
+                                            "workReport": {
+                                              "workReportId": 22,
+                                              "sequence": 2
+                                            }
+                                          }
+                                        ],
+                                        "pageNumber": 0,
+                                        "pageSize": 20,
+                                        "totalElements": 50,
+                                        "totalPages": 3,
+                                        "first": true,
+                                        "last": false
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "현장을 찾을 수 없음"
+            )
+    })
+    @GetMapping("/{siteId}/safety-work-documents")
+    @PreAuthorize("hasRole('CORPORATION')")
+    public ResponseEntity<ApiResponse<SafetyWorkDocumentListResponse>> getSafetyWorkDocuments(
+            @Parameter(description = "현장 ID", required = true, example = "1")
+            @PathVariable Long siteId,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        log.info("안전/작업 문서 목록 조회 API 호출: siteId={}, page={}, size={}",
+                siteId, pageable.getPageNumber(), pageable.getPageSize());
+
+        SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+
+        log.info("안전/작업 문서 목록 조회 완료: siteId={}, totalElements={}", siteId, response.getTotalElements());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "안전/작업 문서 목록을 조회했습니다.")
         );
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/site/dto/SafetyWorkDocumentDto.java
+++ b/src/main/java/com/concrete/buildup/domain/site/dto/SafetyWorkDocumentDto.java
@@ -1,0 +1,69 @@
+package com.concrete.buildup.domain.site.dto;
+
+import com.concrete.buildup.domain.safetydoc.enums.SafetyEducationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 날짜별 안전/작업 문서 정보 DTO
+ *
+ * <p>기업 관리자가 현장의 안전교육일지와 작업일보를 날짜별로 조회할 때 사용합니다.</p>
+ */
+@Schema(description = "날짜별 안전/작업 문서 정보")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SafetyWorkDocumentDto {
+
+    @Schema(description = "문서 작성일", example = "2025-11-24")
+    private LocalDate date;
+
+    @Schema(description = "안전교육일지 정보 (해당 날짜에 없으면 null)")
+    private SafetyEducationLogSummary safetyEducationLog;
+
+    @Schema(description = "작업일보 정보 (해당 날짜에 없으면 null)")
+    private WorkReportSummary workReport;
+
+    /**
+     * 안전교육일지 요약 정보
+     */
+    @Schema(description = "안전교육일지 요약 정보")
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SafetyEducationLogSummary {
+
+        @Schema(description = "안전교육일지 ID", example = "15")
+        private Long logId;
+
+        @Schema(description = "상태", example = "COMPLETED")
+        private SafetyEducationStatus status;
+
+        @Schema(description = "교육 과목명", example = "추락 재해 예방 교육")
+        private String educationSubject;
+    }
+
+    /**
+     * 작업일보 요약 정보
+     */
+    @Schema(description = "작업일보 요약 정보")
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class WorkReportSummary {
+
+        @Schema(description = "작업일보 ID", example = "23")
+        private Long workReportId;
+
+        @Schema(description = "해당 날짜의 순번", example = "1")
+        private int sequence;
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/dto/SafetyWorkDocumentListResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/site/dto/SafetyWorkDocumentListResponse.java
@@ -1,0 +1,54 @@
+package com.concrete.buildup.domain.site.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 안전/작업 문서 목록 응답 DTO (페이지네이션 포함)
+ */
+@Schema(description = "안전/작업 문서 목록 응답")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SafetyWorkDocumentListResponse {
+
+    @Schema(description = "문서 목록")
+    private List<SafetyWorkDocumentDto> content;
+
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+    private int pageNumber;
+
+    @Schema(description = "페이지 크기", example = "20")
+    private int pageSize;
+
+    @Schema(description = "전체 항목 수", example = "50")
+    private long totalElements;
+
+    @Schema(description = "전체 페이지 수", example = "3")
+    private int totalPages;
+
+    @Schema(description = "첫 페이지 여부", example = "true")
+    private boolean first;
+
+    @Schema(description = "마지막 페이지 여부", example = "false")
+    private boolean last;
+
+    public static SafetyWorkDocumentListResponse from(Page<SafetyWorkDocumentDto> page) {
+        return SafetyWorkDocumentListResponse.builder()
+                .content(page.getContent())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -4,19 +4,34 @@ import com.concrete.buildup.domain.auth.entity.Corporation;
 import com.concrete.buildup.domain.auth.entity.User;
 import com.concrete.buildup.domain.auth.repository.CorporationRepository;
 import com.concrete.buildup.domain.auth.repository.UserRepository;
+import com.concrete.buildup.domain.safetydoc.entity.SafetyEducationLog;
+import com.concrete.buildup.domain.safetydoc.repository.SafetyEducationLogRepository;
+import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentDto;
+import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentListResponse;
 import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
 import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
 import com.concrete.buildup.domain.site.dto.SiteDetailResponse;
 import com.concrete.buildup.domain.site.entity.Site;
 import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.domain.workreport.entity.WorkReport;
+import com.concrete.buildup.domain.workreport.repository.WorkReportRepository;
 import com.concrete.buildup.global.exception.BusinessException;
 import com.concrete.buildup.global.exception.errorcode.AuthErrorCode;
 import com.concrete.buildup.global.exception.errorcode.SiteErrorCode;
 import com.concrete.buildup.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 현장 관리 서비스
@@ -36,6 +51,8 @@ public class SiteService {
     private final UserRepository userRepository;
     private final CorporationRepository corporationRepository;
     private final SecretKeyService secretKeyService;
+    private final SafetyEducationLogRepository safetyEducationLogRepository;
+    private final WorkReportRepository workReportRepository;
 
     /**
      * 현장 등록
@@ -127,5 +144,95 @@ public class SiteService {
         log.info("현장 상세 조회 완료 - siteId: {}, siteName: {}", siteId, site.getSiteName());
 
         return SiteDetailResponse.from(site);
+    }
+
+    /**
+     * 현장의 안전/작업 문서 목록 조회 (기업 관리자용)
+     *
+     * <p>날짜별로 안전교육일지와 작업일보를 통합하여 조회합니다.</p>
+     * <p>페이지네이션을 지원하며, 최신 날짜순으로 정렬됩니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param pageable 페이지네이션 정보
+     * @return 날짜별 안전/작업 문서 목록
+     */
+    public SafetyWorkDocumentListResponse getSafetyWorkDocuments(Long siteId, Pageable pageable) {
+        log.info("안전/작업 문서 목록 조회 - siteId: {}, page: {}, size: {}",
+                siteId, pageable.getPageNumber(), pageable.getPageSize());
+
+        // 현장 존재 여부 확인
+        if (!siteRepository.existsById(siteId)) {
+            throw new BusinessException(SiteErrorCode.SITE_NOT_FOUND);
+        }
+
+        // 두 테이블에서 날짜 목록 조회
+        Page<LocalDate> safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable);
+        Page<LocalDate> workReportDates = workReportRepository.findDistinctDatesBySiteId(siteId, pageable);
+
+        // 날짜 병합 및 정렬
+        Set<LocalDate> allDates = new HashSet<>();
+        allDates.addAll(safetyDates.getContent());
+        allDates.addAll(workReportDates.getContent());
+
+        List<LocalDate> sortedDates = allDates.stream()
+                .sorted((d1, d2) -> d2.compareTo(d1))  // 내림차순
+                .collect(Collectors.toList());
+
+        // 페이지네이션 적용
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), sortedDates.size());
+
+        List<LocalDate> pagedDates = start < sortedDates.size()
+                ? sortedDates.subList(start, end)
+                : List.of();
+
+        // 각 날짜별 문서 정보 조회
+        List<SafetyWorkDocumentDto> documents = pagedDates.stream()
+                .map(date -> buildDocumentDto(siteId, date))
+                .collect(Collectors.toList());
+
+        // 전체 카운트 계산 (중복 제거된 날짜 수)
+        long totalElements = allDates.size();
+        int totalPages = (int) Math.ceil((double) totalElements / pageable.getPageSize());
+
+        Page<SafetyWorkDocumentDto> page = new PageImpl<>(documents, pageable, totalElements);
+
+        log.info("안전/작업 문서 목록 조회 완료 - siteId: {}, totalDates: {}", siteId, totalElements);
+
+        return SafetyWorkDocumentListResponse.from(page);
+    }
+
+    /**
+     * 특정 날짜의 안전/작업 문서 DTO 생성
+     */
+    private SafetyWorkDocumentDto buildDocumentDto(Long siteId, LocalDate date) {
+        // 해당 날짜의 안전교육일지 조회 (가장 최근 것)
+        List<SafetyEducationLog> safetyLogs = safetyEducationLogRepository.findBySiteIdAndDate(siteId, date);
+        SafetyWorkDocumentDto.SafetyEducationLogSummary safetySummary = null;
+        if (!safetyLogs.isEmpty()) {
+            SafetyEducationLog log = safetyLogs.get(0);
+            safetySummary = SafetyWorkDocumentDto.SafetyEducationLogSummary.builder()
+                    .logId(log.getId())
+                    .status(log.getStatus())
+                    .educationSubject(log.getEducationSubject())
+                    .build();
+        }
+
+        // 해당 날짜의 작업일보 조회 (가장 최근 것)
+        List<WorkReport> workReports = workReportRepository.findBySiteIdAndDate(siteId, date);
+        SafetyWorkDocumentDto.WorkReportSummary workSummary = null;
+        if (!workReports.isEmpty()) {
+            WorkReport report = workReports.get(0);
+            workSummary = SafetyWorkDocumentDto.WorkReportSummary.builder()
+                    .workReportId(report.getId())
+                    .sequence(workReports.size())  // 해당 날짜의 작업일보 개수
+                    .build();
+        }
+
+        return SafetyWorkDocumentDto.builder()
+                .date(date)
+                .safetyEducationLog(safetySummary)
+                .workReport(workSummary)
+                .build();
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -205,28 +205,24 @@ public class SiteService {
      * 특정 날짜의 안전/작업 문서 DTO 생성
      */
     private SafetyWorkDocumentDto buildDocumentDto(Long siteId, LocalDate date) {
-        // 해당 날짜의 안전교육일지 조회 (가장 최근 것)
-        List<SafetyEducationLog> safetyLogs = safetyEducationLogRepository.findBySiteIdAndDate(siteId, date);
-        SafetyWorkDocumentDto.SafetyEducationLogSummary safetySummary = null;
-        if (!safetyLogs.isEmpty()) {
-            SafetyEducationLog log = safetyLogs.get(0);
-            safetySummary = SafetyWorkDocumentDto.SafetyEducationLogSummary.builder()
-                    .logId(log.getId())
-                    .status(log.getStatus())
-                    .educationSubject(log.getEducationSubject())
-                    .build();
-        }
+        // 해당 날짜의 안전교육일지 조회 (가장 최근 것 1개)
+        SafetyWorkDocumentDto.SafetyEducationLogSummary safetySummary =
+                safetyEducationLogRepository.findLatestBySiteIdAndDate(siteId, date)
+                        .map(safetyLog -> SafetyWorkDocumentDto.SafetyEducationLogSummary.builder()
+                                .logId(safetyLog.getId())
+                                .status(safetyLog.getStatus())
+                                .educationSubject(safetyLog.getEducationSubject())
+                                .build())
+                        .orElse(null);
 
-        // 해당 날짜의 작업일보 조회 (가장 최근 것)
-        List<WorkReport> workReports = workReportRepository.findBySiteIdAndDate(siteId, date);
-        SafetyWorkDocumentDto.WorkReportSummary workSummary = null;
-        if (!workReports.isEmpty()) {
-            WorkReport report = workReports.get(0);
-            workSummary = SafetyWorkDocumentDto.WorkReportSummary.builder()
-                    .workReportId(report.getId())
-                    .sequence(workReports.size())  // 해당 날짜의 작업일보 개수
-                    .build();
-        }
+        // 해당 날짜의 작업일보 조회 (가장 최근 것 1개)
+        SafetyWorkDocumentDto.WorkReportSummary workSummary =
+                workReportRepository.findLatestBySiteIdAndDate(siteId, date)
+                        .map(workReport -> SafetyWorkDocumentDto.WorkReportSummary.builder()
+                                .workReportId(workReport.getId())
+                                .sequence(1)
+                                .build())
+                        .orElse(null);
 
         return SafetyWorkDocumentDto.builder()
                 .date(date)

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -165,20 +165,20 @@ public class SiteService {
             throw new BusinessException(SiteErrorCode.SITE_NOT_FOUND);
         }
 
-        // 두 테이블에서 날짜 목록 조회
-        Page<LocalDate> safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable);
-        Page<LocalDate> workReportDates = workReportRepository.findDistinctDatesBySiteId(siteId, pageable);
+        // 두 테이블에서 전체 날짜 목록 조회 (페이지네이션 없이)
+        List<LocalDate> safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteId(siteId);
+        List<LocalDate> workReportDates = workReportRepository.findDistinctDatesBySiteId(siteId);
 
         // 날짜 병합 및 정렬
         Set<LocalDate> allDates = new HashSet<>();
-        allDates.addAll(safetyDates.getContent());
-        allDates.addAll(workReportDates.getContent());
+        allDates.addAll(safetyDates);
+        allDates.addAll(workReportDates);
 
         List<LocalDate> sortedDates = allDates.stream()
                 .sorted((d1, d2) -> d2.compareTo(d1))  // 내림차순
                 .collect(Collectors.toList());
 
-        // 페이지네이션 적용
+        // 서비스에서 페이지네이션 적용
         int start = (int) pageable.getOffset();
         int end = Math.min(start + pageable.getPageSize(), sortedDates.size());
 
@@ -191,9 +191,8 @@ public class SiteService {
                 .map(date -> buildDocumentDto(siteId, date))
                 .collect(Collectors.toList());
 
-        // 전체 카운트 계산 (중복 제거된 날짜 수)
-        long totalElements = allDates.size();
-        int totalPages = (int) Math.ceil((double) totalElements / pageable.getPageSize());
+        // 전체 카운트는 병합된 날짜 수
+        long totalElements = sortedDates.size();
 
         Page<SafetyWorkDocumentDto> page = new PageImpl<>(documents, pageable, totalElements);
 

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -201,13 +202,17 @@ public class SiteService {
         return SafetyWorkDocumentListResponse.from(page);
     }
 
+    private static final Pageable SINGLE_RESULT = PageRequest.of(0, 1);
+
     /**
      * 특정 날짜의 안전/작업 문서 DTO 생성
      */
     private SafetyWorkDocumentDto buildDocumentDto(Long siteId, LocalDate date) {
         // 해당 날짜의 안전교육일지 조회 (가장 최근 것 1개)
         SafetyWorkDocumentDto.SafetyEducationLogSummary safetySummary =
-                safetyEducationLogRepository.findLatestBySiteIdAndDate(siteId, date)
+                safetyEducationLogRepository.findBySiteIdAndDate(siteId, date, SINGLE_RESULT)
+                        .stream()
+                        .findFirst()
                         .map(safetyLog -> SafetyWorkDocumentDto.SafetyEducationLogSummary.builder()
                                 .logId(safetyLog.getId())
                                 .status(safetyLog.getStatus())
@@ -217,7 +222,9 @@ public class SiteService {
 
         // 해당 날짜의 작업일보 조회 (가장 최근 것 1개)
         SafetyWorkDocumentDto.WorkReportSummary workSummary =
-                workReportRepository.findLatestBySiteIdAndDate(siteId, date)
+                workReportRepository.findBySiteIdAndDate(siteId, date, SINGLE_RESULT)
+                        .stream()
+                        .findFirst()
                         .map(workReport -> SafetyWorkDocumentDto.WorkReportSummary.builder()
                                 .workReportId(workReport.getId())
                                 .sequence(1)

--- a/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 작업일보 Repository
@@ -52,11 +53,16 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
 
     /**
      * 현장별, 날짜별 작업일보 조회 (가장 최근 것 1개)
+     *
+     * @param siteId 현장 ID
+     * @param date 조회 날짜
+     * @return 해당 날짜의 가장 최근 작업일보 (없으면 Optional.empty())
      */
     @Query("SELECT w FROM WorkReport w " +
             "WHERE w.site.id = :siteId " +
             "AND CAST(w.createdAt AS LocalDate) = :date " +
             "AND w.isDeleted = false " +
-            "ORDER BY w.createdAt DESC")
-    List<WorkReport> findBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
+            "ORDER BY w.createdAt DESC " +
+            "LIMIT 1")
+    Optional<WorkReport> findLatestBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
@@ -1,8 +1,6 @@
 package com.concrete.buildup.domain.workreport.repository;
 
 import com.concrete.buildup.domain.workreport.entity.WorkReport;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -45,12 +43,12 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
     List<WorkReport> findByManagerIdAndIsDeletedFalseOrderByCreatedAtDesc(Long managerId);
 
     /**
-     * 현장별 작업일보가 있는 날짜 목록 조회 (중복 제거, 페이지네이션)
+     * 현장별 작업일보가 있는 날짜 목록 조회 (중복 제거)
      */
     @Query("SELECT DISTINCT CAST(w.createdAt AS LocalDate) FROM WorkReport w " +
             "WHERE w.site.id = :siteId AND w.isDeleted = false " +
             "ORDER BY CAST(w.createdAt AS LocalDate) DESC")
-    Page<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId, Pageable pageable);
+    List<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId);
 
     /**
      * 현장별, 날짜별 작업일보 조회 (가장 최근 것 1개)

--- a/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
@@ -1,9 +1,14 @@
 package com.concrete.buildup.domain.workreport.repository;
 
 import com.concrete.buildup.domain.workreport.entity.WorkReport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -38,4 +43,22 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
      * @return 작업일보 목록
      */
     List<WorkReport> findByManagerIdAndIsDeletedFalseOrderByCreatedAtDesc(Long managerId);
+
+    /**
+     * 현장별 작업일보가 있는 날짜 목록 조회 (중복 제거, 페이지네이션)
+     */
+    @Query("SELECT DISTINCT CAST(w.createdAt AS LocalDate) FROM WorkReport w " +
+            "WHERE w.site.id = :siteId AND w.isDeleted = false " +
+            "ORDER BY CAST(w.createdAt AS LocalDate) DESC")
+    Page<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId, Pageable pageable);
+
+    /**
+     * 현장별, 날짜별 작업일보 조회 (가장 최근 것 1개)
+     */
+    @Query("SELECT w FROM WorkReport w " +
+            "WHERE w.site.id = :siteId " +
+            "AND CAST(w.createdAt AS LocalDate) = :date " +
+            "AND w.isDeleted = false " +
+            "ORDER BY w.createdAt DESC")
+    List<WorkReport> findBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * 작업일보 Repository
@@ -52,17 +53,20 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
     List<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId);
 
     /**
-     * 현장별, 날짜별 작업일보 조회 (가장 최근 것 1개)
+     * 현장별, 날짜별 작업일보 조회 (페이지네이션 지원)
      *
      * @param siteId 현장 ID
      * @param date 조회 날짜
-     * @return 해당 날짜의 가장 최근 작업일보 (없으면 Optional.empty())
+     * @param pageable 페이지네이션 정보
+     * @return 해당 날짜의 작업일보 목록 (createdAt 내림차순)
      */
     @Query("SELECT w FROM WorkReport w " +
             "WHERE w.site.id = :siteId " +
             "AND CAST(w.createdAt AS LocalDate) = :date " +
             "AND w.isDeleted = false " +
-            "ORDER BY w.createdAt DESC " +
-            "LIMIT 1")
-    Optional<WorkReport> findLatestBySiteIdAndDate(@Param("siteId") Long siteId, @Param("date") LocalDate date);
+            "ORDER BY w.createdAt DESC")
+    List<WorkReport> findBySiteIdAndDate(
+            @Param("siteId") Long siteId,
+            @Param("date") LocalDate date,
+            Pageable pageable);
 }

--- a/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
@@ -27,8 +27,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -269,12 +267,9 @@ class SiteServiceTest {
                     .build();
             setId(workReport, 1L);
 
-            Page<LocalDate> safetyDates = new PageImpl<>(List.of(date1), pageable, 1);
-            Page<LocalDate> workDates = new PageImpl<>(List.of(date1), pageable, 1);
-
             given(siteRepository.existsById(siteId)).willReturn(true);
-            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(safetyDates);
-            given(workReportRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(workDates);
+            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
+            given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
             given(safetyEducationLogRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(safetyLog));
             given(workReportRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(workReport));
 
@@ -320,12 +315,9 @@ class SiteServiceTest {
                     .build();
             setId(safetyLog, 1L);
 
-            Page<LocalDate> safetyDates = new PageImpl<>(List.of(date1), pageable, 1);
-            Page<LocalDate> workDates = new PageImpl<>(List.of(), pageable, 0);
-
             given(siteRepository.existsById(siteId)).willReturn(true);
-            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(safetyDates);
-            given(workReportRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(workDates);
+            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
+            given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of());
             given(safetyEducationLogRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(safetyLog));
             given(workReportRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of());
 
@@ -361,11 +353,9 @@ class SiteServiceTest {
             Long siteId = 1L;
             Pageable pageable = PageRequest.of(0, 20);
 
-            Page<LocalDate> emptyDates = new PageImpl<>(List.of(), pageable, 0);
-
             given(siteRepository.existsById(siteId)).willReturn(true);
-            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(emptyDates);
-            given(workReportRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(emptyDates);
+            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of());
+            given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of());
 
             // when
             SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);

--- a/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
@@ -4,23 +4,36 @@ import com.concrete.buildup.domain.auth.entity.Corporation;
 import com.concrete.buildup.domain.auth.entity.User;
 import com.concrete.buildup.domain.auth.repository.CorporationRepository;
 import com.concrete.buildup.domain.auth.repository.UserRepository;
+import com.concrete.buildup.domain.safetydoc.entity.SafetyEducationLog;
+import com.concrete.buildup.domain.safetydoc.enums.EducationType;
+import com.concrete.buildup.domain.safetydoc.enums.SafetyEducationStatus;
+import com.concrete.buildup.domain.safetydoc.repository.SafetyEducationLogRepository;
+import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentListResponse;
 import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
 import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
 import com.concrete.buildup.domain.site.entity.Site;
 import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.domain.workreport.entity.WorkReport;
+import com.concrete.buildup.domain.workreport.repository.WorkReportRepository;
 import com.concrete.buildup.global.exception.BusinessException;
 import com.concrete.buildup.global.exception.errorcode.AuthErrorCode;
 import com.concrete.buildup.global.exception.errorcode.SiteErrorCode;
 import com.concrete.buildup.global.util.SecurityUtil;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +65,12 @@ class SiteServiceTest {
 
     @Mock
     private SecretKeyService secretKeyService;
+
+    @Mock
+    private SafetyEducationLogRepository safetyEducationLogRepository;
+
+    @Mock
+    private WorkReportRepository workReportRepository;
 
     @InjectMocks
     private SiteService siteService;
@@ -207,6 +226,154 @@ class SiteServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", SiteErrorCode.INVALID_DATE_RANGE);
 
             verify(siteRepository, never()).save(any(Site.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("안전/작업 문서 목록 조회")
+    class GetSafetyWorkDocuments {
+
+        @Test
+        @DisplayName("성공 - 안전교육일지와 작업일보가 모두 있는 날짜")
+        void success_bothDocumentsExist() throws Exception {
+            // given
+            Long siteId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+            LocalDate date1 = LocalDate.of(2025, 11, 24);
+
+            Corporation corporation = Corporation.builder().corpName("Test Corp").build();
+            setId(corporation, 1L);
+
+            Site site = Site.builder()
+                    .siteName("테스트 현장")
+                    .corporation(corporation)
+                    .build();
+            setId(site, siteId);
+
+            SafetyEducationLog safetyLog = SafetyEducationLog.builder()
+                    .site(site)
+                    .educationType(EducationType.REGULAR)
+                    .educationSubject("추락 재해 예방")
+                    .educationContent("테스트")
+                    .instructorName("김안전")
+                    .educationLocation("현장")
+                    .status(SafetyEducationStatus.COMPLETED)
+                    .corporation(corporation)
+                    .build();
+            setId(safetyLog, 1L);
+
+            WorkReport workReport = WorkReport.builder()
+                    .site(site)
+                    .workSections("[{\"sectionName\":\"철근\"}]")
+                    .corporation(corporation)
+                    .build();
+            setId(workReport, 1L);
+
+            Page<LocalDate> safetyDates = new PageImpl<>(List.of(date1), pageable, 1);
+            Page<LocalDate> workDates = new PageImpl<>(List.of(date1), pageable, 1);
+
+            given(siteRepository.existsById(siteId)).willReturn(true);
+            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(safetyDates);
+            given(workReportRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(workDates);
+            given(safetyEducationLogRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(safetyLog));
+            given(workReportRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(workReport));
+
+            // when
+            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getDate()).isEqualTo(date1);
+            assertThat(response.getContent().get(0).getSafetyEducationLog()).isNotNull();
+            assertThat(response.getContent().get(0).getSafetyEducationLog().getLogId()).isEqualTo(1L);
+            assertThat(response.getContent().get(0).getWorkReport()).isNotNull();
+            assertThat(response.getContent().get(0).getWorkReport().getWorkReportId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("성공 - 안전교육일지만 있는 날짜")
+        void success_onlySafetyLog() throws Exception {
+            // given
+            Long siteId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+            LocalDate date1 = LocalDate.of(2025, 11, 24);
+
+            Corporation corporation = Corporation.builder().corpName("Test Corp").build();
+            setId(corporation, 1L);
+
+            Site site = Site.builder()
+                    .siteName("테스트 현장")
+                    .corporation(corporation)
+                    .build();
+            setId(site, siteId);
+
+            SafetyEducationLog safetyLog = SafetyEducationLog.builder()
+                    .site(site)
+                    .educationType(EducationType.REGULAR)
+                    .educationSubject("추락 재해 예방")
+                    .educationContent("테스트")
+                    .instructorName("김안전")
+                    .educationLocation("현장")
+                    .status(SafetyEducationStatus.COMPLETED)
+                    .corporation(corporation)
+                    .build();
+            setId(safetyLog, 1L);
+
+            Page<LocalDate> safetyDates = new PageImpl<>(List.of(date1), pageable, 1);
+            Page<LocalDate> workDates = new PageImpl<>(List.of(), pageable, 0);
+
+            given(siteRepository.existsById(siteId)).willReturn(true);
+            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(safetyDates);
+            given(workReportRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(workDates);
+            given(safetyEducationLogRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(safetyLog));
+            given(workReportRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of());
+
+            // when
+            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getSafetyEducationLog()).isNotNull();
+            assertThat(response.getContent().get(0).getWorkReport()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패 - 현장이 존재하지 않음")
+        void fail_siteNotFound() {
+            // given
+            Long siteId = 999L;
+            Pageable pageable = PageRequest.of(0, 20);
+
+            given(siteRepository.existsById(siteId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> siteService.getSafetyWorkDocuments(siteId, pageable))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", SiteErrorCode.SITE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("성공 - 문서가 없는 경우 빈 목록 반환")
+        void success_noDocuments() {
+            // given
+            Long siteId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+
+            Page<LocalDate> emptyDates = new PageImpl<>(List.of(), pageable, 0);
+
+            given(siteRepository.existsById(siteId)).willReturn(true);
+            given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(emptyDates);
+            given(workReportRepository.findDistinctDatesBySiteId(siteId, pageable)).willReturn(emptyDates);
+
+            // when
+            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).isEmpty();
+            assertThat(response.getTotalElements()).isZero();
         }
     }
 }

--- a/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -270,8 +271,8 @@ class SiteServiceTest {
             given(siteRepository.existsById(siteId)).willReturn(true);
             given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
             given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
-            given(safetyEducationLogRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.of(safetyLog));
-            given(workReportRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.of(workReport));
+            given(safetyEducationLogRepository.findBySiteIdAndDate(eq(siteId), eq(date1), any(Pageable.class))).willReturn(List.of(safetyLog));
+            given(workReportRepository.findBySiteIdAndDate(eq(siteId), eq(date1), any(Pageable.class))).willReturn(List.of(workReport));
 
             // when
             SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
@@ -318,8 +319,8 @@ class SiteServiceTest {
             given(siteRepository.existsById(siteId)).willReturn(true);
             given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
             given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of());
-            given(safetyEducationLogRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.of(safetyLog));
-            given(workReportRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.empty());
+            given(safetyEducationLogRepository.findBySiteIdAndDate(eq(siteId), eq(date1), any(Pageable.class))).willReturn(List.of(safetyLog));
+            given(workReportRepository.findBySiteIdAndDate(eq(siteId), eq(date1), any(Pageable.class))).willReturn(List.of());
 
             // when
             SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);

--- a/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
@@ -270,8 +270,8 @@ class SiteServiceTest {
             given(siteRepository.existsById(siteId)).willReturn(true);
             given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
             given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
-            given(safetyEducationLogRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(safetyLog));
-            given(workReportRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(workReport));
+            given(safetyEducationLogRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.of(safetyLog));
+            given(workReportRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.of(workReport));
 
             // when
             SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
@@ -318,8 +318,8 @@ class SiteServiceTest {
             given(siteRepository.existsById(siteId)).willReturn(true);
             given(safetyEducationLogRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of(date1));
             given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of());
-            given(safetyEducationLogRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of(safetyLog));
-            given(workReportRepository.findBySiteIdAndDate(siteId, date1)).willReturn(List.of());
+            given(safetyEducationLogRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.of(safetyLog));
+            given(workReportRepository.findLatestBySiteIdAndDate(siteId, date1)).willReturn(Optional.empty());
 
             // when
             SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-182](https://buildupteam.atlassian.net/browse/BU-182)

## 📝 변경 사항 요약
기업 관리자가 현장의 안전교육일지와 작업일보를 날짜별로 통합 조회할 수 있는 API를 추가합니다.

### 주요 변경사항
- `GET /v1/sites/{siteId}/safety-work-documents` 엔드포인트 추가
- 날짜별 안전교육일지 + 작업일보 통합 조회
- 페이지네이션 지원 (기본 size=20)

## 🎯 변경 목적
와이어프레임의 기업 관리자 화면에서 "안전/작업" 네비게이션 버튼 클릭 시 표시되는 날짜별 문서 목록을 조회하기 위함

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] `GET /v1/sites/{siteId}/safety-work-documents` - 안전/작업 문서 통합 목록 조회 API
- [x] `SafetyWorkDocumentDto` - 날짜별 문서 정보 DTO
- [x] `SafetyWorkDocumentListResponse` - 페이지네이션 응답 DTO
- [x] `SafetyEducationLogRepository.findDistinctDatesBySiteId()` - 날짜 목록 조회 쿼리
- [x] `WorkReportRepository.findDistinctDatesBySiteId()` - 날짜 목록 조회 쿼리
- [x] `SiteService.getSafetyWorkDocuments()` - 통합 문서 목록 조회 서비스 메서드

## 🧪 테스트 방법

### 단위 테스트
- [x] 단위 테스트 작성 완료 (4개 테스트 케이스)
- [x] 기존 테스트 통과 확인

### API 테스트 예시
```bash
# 안전/작업 문서 목록 조회 (기업 관리자)
curl -X GET "http://localhost:8080/api/v1/sites/1/safety-work-documents?page=0&size=20" \
  -H "Authorization: Bearer {CORPORATION_ACCESS_TOKEN}"
```

**예상 결과:**
```json
{
  "success": true,
  "message": "안전/작업 문서 목록을 조회했습니다.",
  "data": {
    "content": [
      {
        "date": "2025-11-24",
        "safetyEducationLog": {
          "logId": 15,
          "status": "COMPLETED",
          "educationSubject": "추락 재해 예방 교육"
        },
        "workReport": {
          "workReportId": 23,
          "sequence": 1
        }
      },
      {
        "date": "2025-11-23",
        "safetyEducationLog": null,
        "workReport": {
          "workReportId": 22,
          "sequence": 2
        }
      }
    ],
    "pageNumber": 0,
    "pageSize": 20,
    "totalElements": 50,
    "totalPages": 3,
    "first": true,
    "last": false
  }
}
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거
- [x] 로그 레벨 적절히 설정

### 테스트
- [x] 단위 테스트 작성 완료
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토 (JPQL 파라미터 바인딩 사용)
- [x] 인증/인가 로직 검토 (CORPORATION 권한 필요)

### 문서
- [x] API 문서 업데이트 (Swagger 주석)

### Git
- [x] Conventional Commits 규칙 준수
- [x] develop 브랜치 최신 코드 반영

## 📌 리뷰어에게
- 기업 관리자(CORPORATION) 권한만 접근 가능하도록 설정했습니다
- 두 테이블(safety_education_logs, work_reports)의 날짜를 병합하여 중복 제거 후 페이지네이션을 적용합니다
- 각 날짜별로 가장 최근 문서 1개씩만 반환합니다

[BU-182]: https://build-up-project.atlassian.net/browse/BU-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사이트별로 날짜 기준의 안전 교육 로그와 작업 보고서를 병합해 조회하는 API 추가(페이지네이션 지원). 각 날짜별로 해당일의 최신 항목을 함께 제공.

* **문서**
  * 새 API에 대한 OpenAPI/Swagger 설명 및 예시 응답 추가.

* **테스트**
  * 병합 조회 기능에 대한 포괄적 단위 테스트(정상/예외/페이징) 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->