### PR TITLE
feature/BU-183: 현장 관리자용 작업일보 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
@@ -2,6 +2,7 @@ package com.concrete.buildup.domain.workreport.controller;
 
 import com.concrete.buildup.domain.workreport.dto.CreateWorkReportRequest;
 import com.concrete.buildup.domain.workreport.dto.CreateWorkReportResponse;
+import com.concrete.buildup.domain.workreport.dto.WorkReportListResponse;
 import com.concrete.buildup.domain.workreport.service.WorkReportService;
 import com.concrete.buildup.global.common.ApiResponse;
 import com.concrete.buildup.global.util.SecurityUtil;
@@ -14,6 +15,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -105,5 +108,58 @@ public class WorkReportController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response, "작업일보가 생성되었습니다"));
+    }
+
+    /**
+     * 작업일보 목록 조회 API (현장 관리자용)
+     *
+     * <p>현장에 속한 작업일보 목록을 페이지네이션하여 조회합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param pageable 페이지네이션 정보 (기본값: page=0, size=20)
+     * @return WorkReportListResponse - 작업일보 목록
+     */
+    @Operation(
+            summary = "작업일보 목록 조회 (현장 관리자용)",
+            description = """
+                현장에 속한 작업일보 목록을 조회합니다.
+
+                **조회 정보:**
+                - 작업일보 ID
+                - 작업일자
+                - 작성자 이름
+
+                **정렬:** 최신 작성일순 (내림차순)
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = WorkReportListResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "현장을 찾을 수 없음"
+            )
+    })
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<WorkReportListResponse>> getWorkReportList(
+            @Parameter(description = "현장 ID", required = true, example = "1")
+            @PathVariable Long siteId,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        log.info("작업일보 목록 조회 API 호출: siteId={}, page={}, size={}",
+                siteId, pageable.getPageNumber(), pageable.getPageSize());
+
+        WorkReportListResponse response = workReportService.getWorkReportList(siteId, pageable);
+
+        log.info("작업일보 목록 조회 완료: siteId={}, totalElements={}", siteId, response.getTotalElements());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "작업일보 목록을 조회했습니다")
+        );
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/workreport/dto/WorkReportListResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/dto/WorkReportListResponse.java
@@ -1,0 +1,75 @@
+package com.concrete.buildup.domain.workreport.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 작업일보 목록 조회 응답 DTO (현장 관리자용)
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@Schema(description = "작업일보 목록 응답")
+public class WorkReportListResponse {
+
+    @Schema(description = "작업일보 목록")
+    private List<WorkReportSummary> content;
+
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+    private int pageNumber;
+
+    @Schema(description = "페이지 크기", example = "20")
+    private int pageSize;
+
+    @Schema(description = "전체 요소 수", example = "100")
+    private long totalElements;
+
+    @Schema(description = "전체 페이지 수", example = "5")
+    private int totalPages;
+
+    @Schema(description = "첫 페이지 여부", example = "true")
+    private boolean first;
+
+    @Schema(description = "마지막 페이지 여부", example = "false")
+    private boolean last;
+
+    /**
+     * 작업일보 요약 정보
+     */
+    @Getter
+    @Builder
+    @Schema(description = "작업일보 요약 정보")
+    public static class WorkReportSummary {
+
+        @Schema(description = "작업일보 ID", example = "1")
+        private Long workReportId;
+
+        @Schema(description = "작업일자", example = "2025-11-24")
+        private LocalDate workDate;
+
+        @Schema(description = "작성자 이름", example = "김현장")
+        private String writerName;
+    }
+
+    /**
+     * Page 객체로부터 응답 DTO 생성
+     */
+    public static WorkReportListResponse from(Page<WorkReportSummary> page) {
+        return WorkReportListResponse.builder()
+                .content(page.getContent())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
@@ -69,4 +70,18 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
             @Param("siteId") Long siteId,
             @Param("date") LocalDate date,
             Pageable pageable);
+
+    /**
+     * 현장별 작업일보 목록 조회 (페이지네이션 지원, Manager fetch join)
+     *
+     * @param siteId 현장 ID
+     * @param pageable 페이지네이션 정보
+     * @return 작업일보 페이지 (createdAt 내림차순)
+     */
+    @Query("SELECT w FROM WorkReport w " +
+            "JOIN FETCH w.manager m " +
+            "WHERE w.site.id = :siteId " +
+            "AND w.isDeleted = false " +
+            "ORDER BY w.createdAt DESC")
+    Page<WorkReport> findBySiteIdWithManager(@Param("siteId") Long siteId, Pageable pageable);
 }

--- a/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
@@ -10,6 +10,7 @@ import com.concrete.buildup.domain.upload.service.S3Service;
 import com.concrete.buildup.domain.workreport.dto.CreateWorkReportRequest;
 import com.concrete.buildup.domain.workreport.dto.CreateWorkReportResponse;
 import com.concrete.buildup.domain.workreport.dto.MaterialInputDto;
+import com.concrete.buildup.domain.workreport.dto.WorkReportListResponse;
 import com.concrete.buildup.domain.workreport.entity.WorkReport;
 import com.concrete.buildup.domain.workreport.entity.WorkReportMaterial;
 import com.concrete.buildup.domain.workreport.repository.WorkReportMaterialRepository;
@@ -21,6 +22,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -225,5 +228,41 @@ public class WorkReportService {
      */
     private String buildS3Key(Long workReportId, Long siteId, String createdDate, int sequenceNumber) {
         return String.format("work-reports/%d/%s/WR-%s-%d.pdf", siteId, createdDate, createdDate, sequenceNumber);
+    }
+
+    /**
+     * 현장 관리자용 작업일보 목록 조회
+     *
+     * <p>현장에 속한 작업일보 목록을 페이지네이션하여 조회합니다.</p>
+     * <p>작업일자, 작성자 이름을 포함하여 반환합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param pageable 페이지네이션 정보
+     * @return 작업일보 목록 응답
+     */
+    public WorkReportListResponse getWorkReportList(Long siteId, Pageable pageable) {
+        log.info("작업일보 목록 조회: siteId={}, page={}, size={}",
+                siteId, pageable.getPageNumber(), pageable.getPageSize());
+
+        // 현장 존재 여부 확인
+        if (!siteRepository.existsById(siteId)) {
+            throw new BusinessException(WorkReportErrorCode.SITE_NOT_FOUND);
+        }
+
+        // 작업일보 목록 조회 (Manager fetch join)
+        Page<WorkReport> workReportPage = workReportRepository.findBySiteIdWithManager(siteId, pageable);
+
+        // DTO 변환
+        Page<WorkReportListResponse.WorkReportSummary> summaryPage = workReportPage.map(workReport ->
+                WorkReportListResponse.WorkReportSummary.builder()
+                        .workReportId(workReport.getId())
+                        .workDate(workReport.getCreatedAt().toLocalDate())
+                        .writerName(workReport.getManager().getManagerName())
+                        .build()
+        );
+
+        log.info("작업일보 목록 조회 완료: siteId={}, totalElements={}", siteId, summaryPage.getTotalElements());
+
+        return WorkReportListResponse.from(summaryPage);
     }
 }


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-183](https://buildupteam.atlassian.net/browse/BU-183)

## 📝 변경 사항 요약

### 주요 변경사항
- 현장 관리자용 작업일보 목록 조회 API 추가
- 작업일자, 작성자 이름을 포함한 목록 반환
- 페이지네이션 지원 (기본 20건)

## 🎯 변경 목적
현장 관리자가 자신의 현장에서 작성된 작업일보 목록을 조회할 수 있도록 API를 제공합니다.

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] GET /v1/{siteId}/work-reports 엔드포인트 추가
- [x] WorkReportListResponse DTO 생성 (workReportId, workDate, writerName)
- [x] Manager fetch join으로 N+1 문제 방지
- [x] 페이지네이션 지원 (기본 20건, 최신순 정렬)

### 버그 수정 (Bug Fixes)
- 해당 없음

### 리팩토링 (Refactoring)
- 해당 없음

### 기타 변경사항 (Others)
- 해당 없음

## 🧪 테스트 방법

### 단위 테스트
- [x] 기존 테스트 통과 확인
- `./gradlew clean test` 통과

### API 테스트 예시
```bash
# 작업일보 목록 조회
curl -X GET "http://localhost:8080/api/v1/176/work-reports" \
  -b cookies.txt

# 페이지네이션 테스트
curl -X GET "http://localhost:8080/api/v1/176/work-reports?page=0&size=5" \
  -b cookies.txt
```

**예상 결과:**
```json
{
  "success": true,
  "message": "작업일보 목록을 조회했습니다",
  "data": {
    "content": [
      {
        "workReportId": 15,
        "workDate": "2025-11-21",
        "writerName": "최현장"
      }
    ],
    "pageNumber": 0,
    "pageSize": 20,
    "totalElements": 12,
    "totalPages": 1,
    "first": true,
    "last": true
  }
}
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거
- [x] 로그 레벨 적절히 설정

### 테스트
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토
- [x] 인증/인가 로직 검토 (MANAGER, ADMIN 권한 필요)
- [x] 입력 검증 로직 추가

### 성능
- [x] N+1 쿼리 문제 검토 (Manager fetch join 적용)
- [x] 불필요한 DB 쿼리 최적화

### 문서
- [x] API 문서 업데이트 (Swagger 주석)

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: BU-183`)

## 📌 리뷰어에게
- 현장 관리자가 작업일보 목록을 조회하는 기능입니다.
- 상세보기는 기존 PDF 미리보기/다운로드 API를 활용하면 됩니다.

[BU-183]: https://build-up-project.atlassian.net/browse/BU-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 현장의 작업일보 목록을 페이지 단위로 조회하는 API 엔드포인트 추가
  * 페이지당 기본 20개 항목으로 설정된 페이지네이션 지원
  * 작업일보 요약 정보(작업 날짜, 작성자명) 제공
  * 관리자 이상의 권한 필요

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->