### PR TITLE
feature/BU-185: 근로자 본인 출퇴근 내역 조회 API 추가

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/employee/controller/EmployeeMyController.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/controller/EmployeeMyController.java
@@ -1,0 +1,105 @@
+package com.concrete.buildup.domain.employee.controller;
+
+import com.concrete.buildup.domain.employee.dto.MyAttendanceListResponse;
+import com.concrete.buildup.domain.employee.service.EmployeeMyService;
+import com.concrete.buildup.global.common.ApiResponse;
+import com.concrete.buildup.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 근로자 본인 정보 조회 컨트롤러
+ *
+ * <p>근로자가 본인의 출퇴근 내역, 급여 내역 등을 조회하는 API를 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Slf4j
+@RestController
+@RequestMapping("/v1/employees/me")
+@RequiredArgsConstructor
+@Tag(name = "Employee My", description = "근로자 본인 정보 조회 API")
+public class EmployeeMyController {
+
+    private final EmployeeMyService employeeMyService;
+
+    /**
+     * 본인 출퇴근 내역 조회 API
+     *
+     * <p>로그인한 근로자 본인의 출퇴근 기록을 조회합니다.</p>
+     *
+     * @param pageable 페이지네이션 정보 (기본값: page=0, size=20)
+     * @return MyAttendanceListResponse - 출퇴근 내역 목록
+     */
+    @Operation(
+            summary = "본인 출퇴근 내역 조회",
+            description = """
+                로그인한 근로자 본인의 출퇴근 내역을 조회합니다.
+
+                **조회 정보:**
+                - 날짜
+                - 현장명
+                - 출근 시간
+                - 퇴근 시간 (퇴근 전이면 null)
+                - 근태 상태 (WORKING: 근무중, COMPLETED: 퇴근완료, INCOMPLETE: 미퇴근)
+                - 지각 여부
+
+                **조회 범위:** 최근 6개월
+
+                **정렬:** 최신 날짜순 (내림차순)
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = MyAttendanceListResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (EMPLOYEE 역할 필요)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "근로자 정보를 찾을 수 없음"
+            )
+    })
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @GetMapping("/attendance")
+    public ResponseEntity<ApiResponse<MyAttendanceListResponse>> getMyAttendanceList(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        log.info("본인 출퇴근 내역 조회 API 호출: page={}, size={}",
+                pageable.getPageNumber(), pageable.getPageSize());
+
+        // JWT에서 userId 추출
+        String currentUserId = SecurityUtil.getCurrentUserId();
+
+        MyAttendanceListResponse response = employeeMyService.getMyAttendanceList(currentUserId, pageable);
+
+        log.info("본인 출퇴근 내역 조회 완료: totalElements={}", response.getTotalElements());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "출퇴근 내역을 조회했습니다")
+        );
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/employee/dto/MyAttendanceListResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/dto/MyAttendanceListResponse.java
@@ -1,0 +1,90 @@
+package com.concrete.buildup.domain.employee.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 근로자 본인 출퇴근 내역 응답 DTO
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Schema(description = "본인 출퇴근 내역 응답")
+@Getter
+@Builder
+public class MyAttendanceListResponse {
+
+    @Schema(description = "출퇴근 내역 목록")
+    private List<MyAttendanceSummary> content;
+
+    @Schema(description = "현재 페이지 번호", example = "0")
+    private int pageNumber;
+
+    @Schema(description = "페이지 크기", example = "20")
+    private int pageSize;
+
+    @Schema(description = "전체 요소 수", example = "45")
+    private long totalElements;
+
+    @Schema(description = "전체 페이지 수", example = "3")
+    private int totalPages;
+
+    @Schema(description = "첫 페이지 여부", example = "true")
+    private boolean first;
+
+    @Schema(description = "마지막 페이지 여부", example = "false")
+    private boolean last;
+
+    /**
+     * Page 객체로부터 응답 생성
+     */
+    public static MyAttendanceListResponse from(Page<MyAttendanceSummary> page) {
+        return MyAttendanceListResponse.builder()
+                .content(page.getContent())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .build();
+    }
+
+    /**
+     * 개별 출퇴근 기록 요약
+     */
+    @Schema(description = "출퇴근 기록 요약")
+    @Getter
+    @Builder
+    public static class MyAttendanceSummary {
+
+        @Schema(description = "출퇴근 기록 ID", example = "123")
+        private Long attendanceId;
+
+        @Schema(description = "날짜", example = "2025-11-24")
+        private LocalDate date;
+
+        @Schema(description = "현장 ID", example = "1")
+        private Long siteId;
+
+        @Schema(description = "현장명", example = "강남 현장")
+        private String siteName;
+
+        @Schema(description = "출근 시간", example = "08:55")
+        private String checkInTime;
+
+        @Schema(description = "퇴근 시간 (퇴근 전이면 null)", example = "18:10")
+        private String checkOutTime;
+
+        @Schema(description = "근태 상태 (WORKING: 근무중, COMPLETED: 퇴근완료, ABSENT: 결근)", example = "COMPLETED")
+        private String status;
+
+        @Schema(description = "지각 여부", example = "false")
+        private Boolean isLate;
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeMyService.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeMyService.java
@@ -1,0 +1,192 @@
+package com.concrete.buildup.domain.employee.service;
+
+import com.concrete.buildup.domain.attendance.entity.AttendanceRecord;
+import com.concrete.buildup.domain.attendance.enums.AttendanceState;
+import com.concrete.buildup.domain.attendance.enums.AttendanceType;
+import com.concrete.buildup.domain.attendance.repository.AttendanceRecordRepository;
+import com.concrete.buildup.domain.auth.entity.Employee;
+import com.concrete.buildup.domain.auth.entity.User;
+import com.concrete.buildup.domain.auth.repository.EmployeeRepository;
+import com.concrete.buildup.domain.auth.repository.UserRepository;
+import com.concrete.buildup.domain.employee.dto.MyAttendanceListResponse;
+import com.concrete.buildup.domain.employee.dto.MyAttendanceListResponse.MyAttendanceSummary;
+import com.concrete.buildup.domain.site.entity.Site;
+import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.global.exception.BusinessException;
+import com.concrete.buildup.global.exception.errorcode.EmployeeErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 근로자 본인 정보 조회 서비스
+ *
+ * <p>근로자가 본인의 출퇴근 내역, 급여 내역 등을 조회하는 기능을 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmployeeMyService {
+
+    private final UserRepository userRepository;
+    private final EmployeeRepository employeeRepository;
+    private final AttendanceRecordRepository attendanceRecordRepository;
+    private final SiteRepository siteRepository;
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    /**
+     * 본인 출퇴근 내역 조회
+     *
+     * <p>JWT에서 추출한 userId로 본인의 출퇴근 기록을 조회합니다.</p>
+     * <p>날짜별로 그룹핑하여 출근/퇴근 시간을 하나의 레코드로 반환합니다.</p>
+     *
+     * @param currentUserId JWT에서 추출한 로그인 ID
+     * @param pageable 페이지네이션 정보
+     * @return 본인 출퇴근 내역
+     */
+    public MyAttendanceListResponse getMyAttendanceList(String currentUserId, Pageable pageable) {
+        log.info("본인 출퇴근 내역 조회: userId={}", currentUserId);
+
+        // 1. userId(로그인 ID)로 User 조회
+        User user = userRepository.findByUserId(currentUserId)
+                .orElseThrow(() -> new BusinessException(EmployeeErrorCode.EMPLOYEE_NOT_FOUND));
+
+        // 2. User로 Employee 조회
+        Employee employee = employeeRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new BusinessException(EmployeeErrorCode.EMPLOYEE_NOT_FOUND));
+
+        Long employeeId = employee.getId();
+
+        // 3. 전체 출퇴근 기록 조회 (최근 6개월)
+        LocalDateTime endTime = LocalDateTime.now();
+        LocalDateTime startTime = endTime.minusMonths(6);
+
+        List<AttendanceRecord> allRecords = attendanceRecordRepository
+                .findByEmployeeIdAndTimestampBetween(employeeId, startTime, endTime);
+
+        // 4. CONFIRMED 상태만 필터링
+        List<AttendanceRecord> confirmedRecords = allRecords.stream()
+                .filter(record -> record.getState() == AttendanceState.CONFIRMED)
+                .sorted(Comparator.comparing(AttendanceRecord::getTimestamp).reversed())
+                .toList();
+
+        // 5. 날짜별로 그룹핑하여 출근/퇴근 페어 생성
+        Map<LocalDate, Map<Long, List<AttendanceRecord>>> recordsByDateAndSite = confirmedRecords.stream()
+                .collect(Collectors.groupingBy(
+                        record -> record.getTimestamp().toLocalDate(),
+                        LinkedHashMap::new,
+                        Collectors.groupingBy(AttendanceRecord::getSiteId)
+                ));
+
+        // 6. Site 정보 일괄 조회 (N+1 방지)
+        Set<Long> siteIds = confirmedRecords.stream()
+                .map(AttendanceRecord::getSiteId)
+                .collect(Collectors.toSet());
+        Map<Long, Site> siteMap = siteRepository.findAllById(siteIds).stream()
+                .collect(Collectors.toMap(Site::getId, site -> site));
+
+        // 7. 날짜+현장별 요약 레코드 생성
+        List<MyAttendanceSummary> summaries = new ArrayList<>();
+        for (Map.Entry<LocalDate, Map<Long, List<AttendanceRecord>>> dateEntry : recordsByDateAndSite.entrySet()) {
+            LocalDate date = dateEntry.getKey();
+            for (Map.Entry<Long, List<AttendanceRecord>> siteEntry : dateEntry.getValue().entrySet()) {
+                Long siteId = siteEntry.getKey();
+                List<AttendanceRecord> records = siteEntry.getValue();
+
+                Site site = siteMap.get(siteId);
+                String siteName = site != null ? site.getSiteName() : "알 수 없음";
+
+                // 출근/퇴근 기록 찾기
+                AttendanceRecord checkIn = records.stream()
+                        .filter(r -> r.getAttendanceType() == AttendanceType.CHECK_IN)
+                        .findFirst()
+                        .orElse(null);
+
+                AttendanceRecord checkOut = records.stream()
+                        .filter(r -> r.getAttendanceType() == AttendanceType.CHECK_OUT)
+                        .findFirst()
+                        .orElse(null);
+
+                // 출근 기록이 있어야 유효한 데이터
+                if (checkIn != null) {
+                    String status = determineStatus(checkIn, checkOut);
+                    Boolean isLate = determineIsLate(checkIn);
+
+                    summaries.add(MyAttendanceSummary.builder()
+                            .attendanceId(checkIn.getId())
+                            .date(date)
+                            .siteId(siteId)
+                            .siteName(siteName)
+                            .checkInTime(checkIn.getTimestamp().format(TIME_FORMATTER))
+                            .checkOutTime(checkOut != null ? checkOut.getTimestamp().format(TIME_FORMATTER) : null)
+                            .status(status)
+                            .isLate(isLate)
+                            .build());
+                }
+            }
+        }
+
+        // 8. 날짜 내림차순 정렬
+        summaries.sort(Comparator.comparing(MyAttendanceSummary::getDate).reversed());
+
+        // 9. 페이지네이션 적용
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), summaries.size());
+
+        List<MyAttendanceSummary> pagedContent = start < summaries.size()
+                ? summaries.subList(start, end)
+                : Collections.emptyList();
+
+        Page<MyAttendanceSummary> page = new PageImpl<>(pagedContent, pageable, summaries.size());
+
+        log.info("본인 출퇴근 내역 조회 완료: employeeId={}, totalRecords={}", employeeId, summaries.size());
+
+        return MyAttendanceListResponse.from(page);
+    }
+
+    /**
+     * 근태 상태 결정
+     */
+    private String determineStatus(AttendanceRecord checkIn, AttendanceRecord checkOut) {
+        if (checkOut != null) {
+            return "COMPLETED"; // 퇴근 완료
+        }
+
+        // 출근만 있는 경우 - 당일이면 근무중, 과거면 미퇴근
+        LocalDate today = LocalDate.now();
+        LocalDate checkInDate = checkIn.getTimestamp().toLocalDate();
+
+        if (checkInDate.equals(today)) {
+            return "WORKING"; // 근무중
+        } else {
+            return "INCOMPLETE"; // 미퇴근 (과거 데이터)
+        }
+    }
+
+    /**
+     * 지각 여부 결정
+     * <p>현재는 단순히 9시 이후 출근을 지각으로 판단합니다.</p>
+     * <p>TODO: 계약서의 출근 시간 기준으로 변경 필요</p>
+     */
+    private Boolean determineIsLate(AttendanceRecord checkIn) {
+        LocalTime checkInTime = checkIn.getTimestamp().toLocalTime();
+        LocalTime standardTime = LocalTime.of(9, 5); // 9시 5분 기준 (5분 유예)
+        return checkInTime.isAfter(standardTime);
+    }
+}


### PR DESCRIPTION

# Pull Request

## 📋 Jira Issue
- Jira: [BU-185](https://buildupteam.atlassian.net/browse/BU-185)

## 📝 변경 사항 요약
근로자 앱에서 본인의 출퇴근 내역을 조회할 수 있는 API를 추가합니다.

### 주요 변경사항
- `GET /v1/employees/me/attendance` 엔드포인트 추가
- 근로자 본인 출퇴근 내역 조회 서비스 구현
- 페이지네이션 지원 응답 DTO 추가

## 🎯 변경 목적
근로자 앱에서 본인의 출퇴근 기록(날짜, 출근시간, 퇴근시간, 상태, 지각여부)을 확인할 수 있는 기능이 필요합니다.

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] `EmployeeMyController`: 근로자 본인 정보 조회 API 컨트롤러
- [x] `EmployeeMyService`: 출퇴근 내역 조회 비즈니스 로직
- [x] `MyAttendanceListResponse`: 페이지네이션 포함 응답 DTO

### 버그 수정 (Bug Fixes)
- 해당 없음

### 리팩토링 (Refactoring)
- 해당 없음

### 기타 변경사항 (Others)
- 해당 없음

## 🧪 테스트 방법

### 단위 테스트
- [x] 기존 테스트 통과 확인 (`./gradlew clean test` BUILD SUCCESSFUL)

### API 테스트 예시
```bash
# 근로자 로그인
curl -X POST http://localhost:8080/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"userId": "employee01", "password": "password123"}'

# 본인 출퇴근 내역 조회
curl -X GET "http://localhost:8080/api/v1/employees/me/attendance?page=0&size=20" \
  -H "Authorization: Bearer {accessToken}"
```

**예상 결과:**
```json
{
  "success": true,
  "message": "출퇴근 내역을 조회했습니다",
  "data": {
    "content": [
      {
        "attendanceId": 123,
        "date": "2025-11-24",
        "siteId": 1,
        "siteName": "강남 현장",
        "checkInTime": "08:55",
        "checkOutTime": "18:10",
        "status": "COMPLETED",
        "isLate": false
      }
    ],
    "pageNumber": 0,
    "pageSize": 20,
    "totalElements": 45,
    "totalPages": 3,
    "first": true,
    "last": false
  }
}
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거
- [x] 로그 레벨 적절히 설정

### 테스트
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토 (JPA 사용)
- [x] 인증/인가 로직 검토 (@PreAuthorize("hasRole('EMPLOYEE')"))
- [x] 민감 정보 노출 검토

### 성능
- [x] N+1 쿼리 문제 검토 (Site 일괄 조회로 해결)
- [x] 불필요한 DB 쿼리 최적화

### 문서
- [x] API 문서 업데이트 (Swagger 주석)

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: BU-185`)

## 📌 리뷰어에게
- 지각 여부 판단 로직은 현재 9시 5분 기준으로 구현되어 있습니다. 추후 계약서의 출근 시간 기준으로 변경이 필요할 수 있습니다.
- CONFIRMED 상태의 출퇴근 기록만 조회됩니다.
- 최근 6개월 데이터만 조회됩니다.

[BU-185]: https://build-up-project.atlassian.net/browse/BU-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 직원이 자신의 근태 기록을 조회할 수 있는 새로운 API 엔드포인트 추가
  * 근무 날짜, 출퇴근 시간, 근무 현장명, 근태 상태, 지각 여부 등의 상세 정보 제공
  * 페이지네이션 지원으로 효율적인 데이터 조회 가능 (기본값: 20개 항목)
  * 인증된 직원만 접근 가능한 권한 관리 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->