### PR TITLE
feature/BU-186: 근로자 홈 화면 API 추가 

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/employee/controller/EmployeeMyController.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/controller/EmployeeMyController.java
@@ -1,6 +1,7 @@
 package com.concrete.buildup.domain.employee.controller;
 
 import com.concrete.buildup.domain.employee.dto.MyAttendanceListResponse;
+import com.concrete.buildup.domain.employee.dto.MyHomeResponse;
 import com.concrete.buildup.domain.employee.service.EmployeeMyService;
 import com.concrete.buildup.global.common.ApiResponse;
 import com.concrete.buildup.global.util.SecurityUtil;
@@ -100,6 +101,65 @@ public class EmployeeMyController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(response, "출퇴근 내역을 조회했습니다")
+        );
+    }
+
+    /**
+     * 홈 화면 정보 조회 API
+     *
+     * <p>로그인한 근로자의 홈 화면에 표시할 정보를 조회합니다.</p>
+     *
+     * @return MyHomeResponse - 홈 화면 정보
+     */
+    @Operation(
+            summary = "홈 화면 정보 조회",
+            description = """
+                로그인한 근로자의 홈 화면 정보를 조회합니다.
+
+                **조회 정보:**
+                - 미결 전자계약 (근로계약서 미서명, 안전교육일지 미서명)
+                - 최근 급여 내역 (현장명, 지급일, 실지급액)
+                - 금일 근태 (출근/퇴근 시간, 상태, 지각 여부)
+
+                **참고:**
+                - 미결 전자계약이 없으면 count=0, items=[]
+                - 최근 급여가 없으면 recentSalary=null
+                - 금일 출근 기록이 없으면 todayAttendance=null
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = MyHomeResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (EMPLOYEE 역할 필요)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "근로자 정보를 찾을 수 없음"
+            )
+    })
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @GetMapping("/home")
+    public ResponseEntity<ApiResponse<MyHomeResponse>> getMyHome() {
+        log.info("홈 화면 정보 조회 API 호출");
+
+        // JWT에서 userId 추출
+        String currentUserId = SecurityUtil.getCurrentUserId();
+
+        MyHomeResponse response = employeeMyService.getMyHome(currentUserId);
+
+        log.info("홈 화면 정보 조회 완료: pendingCount={}", response.getPendingContracts().getCount());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "홈 화면 정보를 조회했습니다")
         );
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/employee/dto/MyHomeResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/dto/MyHomeResponse.java
@@ -1,0 +1,120 @@
+package com.concrete.buildup.domain.employee.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 근로자 홈 화면 응답 DTO
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Schema(description = "근로자 홈 화면 응답")
+@Getter
+@Builder
+public class MyHomeResponse {
+
+    @Schema(description = "미결 전자계약 정보")
+    private PendingContractsInfo pendingContracts;
+
+    @Schema(description = "최근 급여 정보 (없으면 null)")
+    private RecentSalaryInfo recentSalary;
+
+    @Schema(description = "금일 근태 정보 (없으면 null)")
+    private TodayAttendanceInfo todayAttendance;
+
+    /**
+     * 미결 전자계약 정보
+     */
+    @Schema(description = "미결 전자계약 정보")
+    @Getter
+    @Builder
+    public static class PendingContractsInfo {
+
+        @Schema(description = "미결 건수", example = "2")
+        private int count;
+
+        @Schema(description = "미결 계약 목록")
+        private List<PendingContractItem> items;
+    }
+
+    /**
+     * 미결 계약 항목
+     */
+    @Schema(description = "미결 계약 항목")
+    @Getter
+    @Builder
+    public static class PendingContractItem {
+
+        @Schema(description = "계약 유형 (CONTRACT: 근로계약서, SAFETY_EDUCATION: 안전교육일지)", example = "CONTRACT")
+        private String type;
+
+        @Schema(description = "계약 ID (type=CONTRACT일 때)", example = "123")
+        private Long contractId;
+
+        @Schema(description = "안전교육일지 ID (type=SAFETY_EDUCATION일 때)", example = "456")
+        private Long safetyLogId;
+
+        @Schema(description = "현장 ID", example = "1")
+        private Long siteId;
+
+        @Schema(description = "현장명", example = "강남 현장")
+        private String siteName;
+    }
+
+    /**
+     * 최근 급여 정보
+     */
+    @Schema(description = "최근 급여 정보")
+    @Getter
+    @Builder
+    public static class RecentSalaryInfo {
+
+        @Schema(description = "급여 ID", example = "789")
+        private Long payrollId;
+
+        @Schema(description = "현장 ID", example = "1")
+        private Long siteId;
+
+        @Schema(description = "현장명", example = "강남 현장")
+        private String siteName;
+
+        @Schema(description = "지급일", example = "2025-11-15")
+        private LocalDate payDate;
+
+        @Schema(description = "실지급액", example = "2850000")
+        private BigDecimal netPay;
+    }
+
+    /**
+     * 금일 근태 정보
+     */
+    @Schema(description = "금일 근태 정보")
+    @Getter
+    @Builder
+    public static class TodayAttendanceInfo {
+
+        @Schema(description = "현장 ID", example = "1")
+        private Long siteId;
+
+        @Schema(description = "현장명", example = "강남 현장")
+        private String siteName;
+
+        @Schema(description = "출근 시간", example = "08:55")
+        private String checkInTime;
+
+        @Schema(description = "퇴근 시간 (퇴근 전이면 null)", example = "18:10")
+        private String checkOutTime;
+
+        @Schema(description = "근태 상태 (WORKING: 근무중, COMPLETED: 퇴근완료)", example = "WORKING")
+        private String status;
+
+        @Schema(description = "지각 여부", example = "false")
+        private Boolean isLate;
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeMyService.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeMyService.java
@@ -8,8 +8,17 @@ import com.concrete.buildup.domain.auth.entity.Employee;
 import com.concrete.buildup.domain.auth.entity.User;
 import com.concrete.buildup.domain.auth.repository.EmployeeRepository;
 import com.concrete.buildup.domain.auth.repository.UserRepository;
+import com.concrete.buildup.domain.contract.entity.Contract;
+import com.concrete.buildup.domain.contract.enums.ContractState;
+import com.concrete.buildup.domain.contract.repository.ContractRepository;
 import com.concrete.buildup.domain.employee.dto.MyAttendanceListResponse;
 import com.concrete.buildup.domain.employee.dto.MyAttendanceListResponse.MyAttendanceSummary;
+import com.concrete.buildup.domain.employee.dto.MyHomeResponse;
+import com.concrete.buildup.domain.employee.dto.MyHomeResponse.*;
+import com.concrete.buildup.domain.payroll.entity.Payroll;
+import com.concrete.buildup.domain.payroll.repository.PayrollRepository;
+import com.concrete.buildup.domain.safetydoc.entity.SafetyEducationAttendee;
+import com.concrete.buildup.domain.safetydoc.repository.SafetyEducationAttendeeRepository;
 import com.concrete.buildup.domain.site.entity.Site;
 import com.concrete.buildup.domain.site.repository.SiteRepository;
 import com.concrete.buildup.global.exception.BusinessException;
@@ -47,6 +56,9 @@ public class EmployeeMyService {
     private final EmployeeRepository employeeRepository;
     private final AttendanceRecordRepository attendanceRecordRepository;
     private final SiteRepository siteRepository;
+    private final ContractRepository contractRepository;
+    private final PayrollRepository payrollRepository;
+    private final SafetyEducationAttendeeRepository safetyEducationAttendeeRepository;
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
@@ -188,5 +200,174 @@ public class EmployeeMyService {
         LocalTime checkInTime = checkIn.getTimestamp().toLocalTime();
         LocalTime standardTime = LocalTime.of(9, 5); // 9시 5분 기준 (5분 유예)
         return checkInTime.isAfter(standardTime);
+    }
+
+    /**
+     * 홈 화면 정보 조회
+     *
+     * <p>근로자 홈 화면에 표시할 정보를 조회합니다.</p>
+     * <ul>
+     *   <li>미결 전자계약 (근로계약서 미서명, 안전교육일지 미서명)</li>
+     *   <li>최근 급여 내역</li>
+     *   <li>금일 근태 정보</li>
+     * </ul>
+     *
+     * @param currentUserId JWT에서 추출한 로그인 ID
+     * @return 홈 화면 정보
+     */
+    public MyHomeResponse getMyHome(String currentUserId) {
+        log.info("홈 화면 정보 조회: userId={}", currentUserId);
+
+        // 1. userId(로그인 ID)로 User 조회
+        User user = userRepository.findByUserId(currentUserId)
+                .orElseThrow(() -> new BusinessException(EmployeeErrorCode.EMPLOYEE_NOT_FOUND));
+
+        // 2. User로 Employee 조회
+        Employee employee = employeeRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new BusinessException(EmployeeErrorCode.EMPLOYEE_NOT_FOUND));
+
+        Long employeeId = employee.getId();
+
+        // 3. 미결 전자계약 조회
+        PendingContractsInfo pendingContracts = getPendingContracts(employeeId);
+
+        // 4. 최근 급여 조회
+        RecentSalaryInfo recentSalary = getRecentSalary(employeeId);
+
+        // 5. 금일 근태 조회
+        TodayAttendanceInfo todayAttendance = getTodayAttendance(employeeId);
+
+        log.info("홈 화면 정보 조회 완료: employeeId={}, pendingCount={}",
+                employeeId, pendingContracts.getCount());
+
+        return MyHomeResponse.builder()
+                .pendingContracts(pendingContracts)
+                .recentSalary(recentSalary)
+                .todayAttendance(todayAttendance)
+                .build();
+    }
+
+    /**
+     * 미결 전자계약 조회
+     */
+    private PendingContractsInfo getPendingContracts(Long employeeId) {
+        List<PendingContractItem> items = new ArrayList<>();
+
+        // 1. 미서명 근로계약서 조회 (EMPLOYEE_SIGNING_PENDING 상태)
+        List<Contract> pendingContracts = contractRepository
+                .findByEmployeeIdAndContractState(employeeId, ContractState.EMPLOYEE_SIGNING_PENDING);
+
+        // Site 정보 일괄 조회
+        Set<Long> managerIds = pendingContracts.stream()
+                .map(Contract::getManagerId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Site> siteByManagerId = new HashMap<>();
+        if (!managerIds.isEmpty()) {
+            // Manager ID로 Site 조회
+            for (Long managerId : managerIds) {
+                siteRepository.findByIdWithManager(managerId)
+                        .ifPresent(site -> siteByManagerId.put(managerId, site));
+            }
+        }
+
+        for (Contract contract : pendingContracts) {
+            Site site = siteByManagerId.get(contract.getManagerId());
+            items.add(PendingContractItem.builder()
+                    .type("CONTRACT")
+                    .contractId(contract.getId())
+                    .siteId(site != null ? site.getId() : null)
+                    .siteName(site != null ? site.getSiteName() : "알 수 없음")
+                    .build());
+        }
+
+        // 2. 미서명 안전교육일지 조회
+        List<SafetyEducationAttendee> unsignedAttendees = safetyEducationAttendeeRepository
+                .findByEmployeeIdAndIsSignedFalse(employeeId);
+
+        for (SafetyEducationAttendee attendee : unsignedAttendees) {
+            Site site = attendee.getSafetyEducationLog().getSite();
+            items.add(PendingContractItem.builder()
+                    .type("SAFETY_EDUCATION")
+                    .safetyLogId(attendee.getSafetyEducationLog().getId())
+                    .siteId(site.getId())
+                    .siteName(site.getSiteName())
+                    .build());
+        }
+
+        return PendingContractsInfo.builder()
+                .count(items.size())
+                .items(items)
+                .build();
+    }
+
+    /**
+     * 최근 급여 조회
+     */
+    private RecentSalaryInfo getRecentSalary(Long employeeId) {
+        List<Payroll> payrolls = payrollRepository.findByEmployeeIdOrderBySearchDateDesc(employeeId);
+
+        if (payrolls.isEmpty()) {
+            return null;
+        }
+
+        Payroll latestPayroll = payrolls.get(0);
+        Site site = siteRepository.findById(latestPayroll.getSiteId()).orElse(null);
+
+        return RecentSalaryInfo.builder()
+                .payrollId(latestPayroll.getId())
+                .siteId(latestPayroll.getSiteId())
+                .siteName(site != null ? site.getSiteName() : "알 수 없음")
+                .payDate(latestPayroll.getSearchDate())
+                .netPay(latestPayroll.getTotalPay())
+                .build();
+    }
+
+    /**
+     * 금일 근태 조회
+     */
+    private TodayAttendanceInfo getTodayAttendance(Long employeeId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(23, 59, 59);
+
+        List<AttendanceRecord> todayRecords = attendanceRecordRepository
+                .findByEmployeeIdAndTimestampBetween(employeeId, startOfDay, endOfDay);
+
+        // CONFIRMED 상태만 필터링
+        List<AttendanceRecord> confirmedRecords = todayRecords.stream()
+                .filter(r -> r.getState() == AttendanceState.CONFIRMED)
+                .toList();
+
+        if (confirmedRecords.isEmpty()) {
+            return null;
+        }
+
+        // 출근/퇴근 기록 찾기
+        AttendanceRecord checkIn = confirmedRecords.stream()
+                .filter(r -> r.getAttendanceType() == AttendanceType.CHECK_IN)
+                .findFirst()
+                .orElse(null);
+
+        AttendanceRecord checkOut = confirmedRecords.stream()
+                .filter(r -> r.getAttendanceType() == AttendanceType.CHECK_OUT)
+                .findFirst()
+                .orElse(null);
+
+        if (checkIn == null) {
+            return null;
+        }
+
+        Site site = siteRepository.findById(checkIn.getSiteId()).orElse(null);
+        String status = checkOut != null ? "COMPLETED" : "WORKING";
+
+        return TodayAttendanceInfo.builder()
+                .siteId(checkIn.getSiteId())
+                .siteName(site != null ? site.getSiteName() : "알 수 없음")
+                .checkInTime(checkIn.getTimestamp().format(TIME_FORMATTER))
+                .checkOutTime(checkOut != null ? checkOut.getTimestamp().format(TIME_FORMATTER) : null)
+                .status(status)
+                .isLate(determineIsLate(checkIn))
+                .build();
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeMyService.java
+++ b/src/main/java/com/concrete/buildup/domain/employee/service/EmployeeMyService.java
@@ -266,7 +266,7 @@ public class EmployeeMyService {
         if (!managerIds.isEmpty()) {
             // Manager ID로 Site 조회
             for (Long managerId : managerIds) {
-                siteRepository.findByIdWithManager(managerId)
+                siteRepository.findByManagerId(managerId)
                         .ifPresent(site -> siteByManagerId.put(managerId, site));
             }
         }

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationAttendeeRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationAttendeeRepository.java
@@ -48,4 +48,17 @@ public interface SafetyEducationAttendeeRepository extends JpaRepository<SafetyE
             @Param("startDate") java.time.LocalDateTime startDate,
             @Param("endDate") java.time.LocalDateTime endDate
     );
+
+    /**
+     * 근로자의 미서명 안전교육일지 참석 목록 조회
+     * N+1 방지를 위해 SafetyEducationLog와 Site를 함께 조회
+     */
+    @Query("SELECT a FROM SafetyEducationAttendee a " +
+            "JOIN FETCH a.safetyEducationLog sel " +
+            "JOIN FETCH sel.site " +
+            "WHERE a.employee.id = :employeeId " +
+            "AND a.isSigned = false " +
+            "AND a.isDeleted = false " +
+            "AND sel.isDeleted = false")
+    List<SafetyEducationAttendee> findByEmployeeIdAndIsSignedFalse(@Param("employeeId") Long employeeId);
 }

--- a/src/main/java/com/concrete/buildup/domain/site/repository/SiteRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/site/repository/SiteRepository.java
@@ -73,4 +73,15 @@ public interface SiteRepository extends JpaRepository<Site, Long> {
      */
     @Query("SELECT s FROM Site s LEFT JOIN FETCH s.manager WHERE s.id = :siteId")
     Optional<Site> findByIdWithManager(@Param("siteId") Long siteId);
+
+    /**
+     * Manager ID로 현장 조회
+     *
+     * <p>Manager 엔티티의 ID로 해당 관리자가 담당하는 현장을 조회합니다.</p>
+     *
+     * @param managerId Manager 엔티티 ID
+     * @return 현장 정보
+     */
+    @Query("SELECT s FROM Site s WHERE s.manager.id = :managerId")
+    Optional<Site> findByManagerId(@Param("managerId") Long managerId);
 }


### PR DESCRIPTION
## Summary
- 근로자 앱 홈 화면 API (`GET /v1/employees/me/home`) 추가

## 주요 기능
### 홈 화면 정보 조회
- **대기 중인 서명**: 미서명 근로계약서 + 미서명 안전교육일지 개수 및 목록
- **최근 급여 정보**: 가장 최근 급여명세서 요약
- **오늘 출퇴근 현황**: 출근/퇴근 시간, 상태(대기/근무중/완료), 지각 여부

## 변경 파일
- `MyHomeResponse.java` - 홈 화면 응답 DTO
- `EmployeeMyService.java` - `getMyHome()` 메서드 추가
- `EmployeeMyController.java` - `/home` 엔드포인트 추가
- `SafetyEducationAttendeeRepository.java` - 미서명 안전교육 조회 쿼리 추가

## API 응답 예시
```json
{
  "pendingContracts": {
    "count": 1,
    "items": [{"type": "SAFETY_EDUCATION", "safetyLogId": 5, "siteName": "송파 아파트 현장"}]
  },
  "recentSalary": {
    "payrollId": 1,
    "siteName": "강남 빌딩 신축현장",
    "payDate": "2025-11-01",
    "netPay": 3000000.00
  },
  "todayAttendance": {
    "checkInTime": "08:30",
    "checkOutTime": "17:30",
    "status": "COMPLETED",
    "isLate": false
  }
}
```

## Test plan
- [x] 로컬 테스트 통과 (`./gradlew test`)
- [x] API 테스트 완료 (EMPLOYEE 권한으로 검증)
- [ ] GitHub Actions CI 테스트

Refs: BU-186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 직원 홈 화면 추가: 대기 중인 계약 목록, 최근 급여 정보, 오늘의 출근 현황(체크인/체크아웃 시간, 지각 여부 포함)을 한 화면에서 확인할 수 있습니다. 각 항목별로 사이트명 및 관련 세부 정보가 함께 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->