### PR TITLE
feature/BU-196: 대시보드 API & 작업일보 및 안전교육일지 API 연도/월 필터링 기능 추가

### DIFF
--- a/migrations/sync-schema-20250126.sql
+++ b/migrations/sync-schema-20250126.sql
@@ -1,0 +1,141 @@
+-- 스키마 동기화 마이그레이션
+-- 생성일: 2025-01-26
+-- 목적: 로컬과 EC2 DB 스키마를 동일하게 맞춤
+-- 적용 순서: 1) 로컬에서 테스트 → 2) EC2에 적용
+
+USE buildup;
+
+-- ============================================
+-- 1. contract_details 테이블 동기화 (EC2용)
+-- ============================================
+-- EC2에 없는 컬럼 추가 (로컬 기준으로 맞춤)
+-- 주의: 로컬에서는 이미 컬럼이 있으므로 에러가 발생할 수 있음 (정상)
+
+-- payday 컬럼이 없으면 추가
+SET @col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = 'buildup'
+    AND TABLE_NAME = 'contract_details'
+    AND COLUMN_NAME = 'payday'
+);
+
+SET @query = IF(@col_exists = 0,
+    'ALTER TABLE contract_details ADD COLUMN payday VARCHAR(255) AFTER pay_type',
+    'SELECT "payday already exists" AS Info'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- work_bonus 컬럼이 없으면 추가
+SET @col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = 'buildup'
+    AND TABLE_NAME = 'contract_details'
+    AND COLUMN_NAME = 'work_bonus'
+);
+
+SET @query = IF(@col_exists = 0,
+    'ALTER TABLE contract_details ADD COLUMN work_bonus DECIMAL(10,2) AFTER payday',
+    'SELECT "work_bonus already exists" AS Info'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- work_off_day 컬럼이 없으면 추가
+SET @col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = 'buildup'
+    AND TABLE_NAME = 'contract_details'
+    AND COLUMN_NAME = 'work_off_day'
+);
+
+SET @query = IF(@col_exists = 0,
+    'ALTER TABLE contract_details ADD COLUMN work_off_day VARCHAR(255) AFTER work_end_time',
+    'SELECT "work_off_day already exists" AS Info'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- work_on_day 컬럼이 없으면 추가
+SET @col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = 'buildup'
+    AND TABLE_NAME = 'contract_details'
+    AND COLUMN_NAME = 'work_on_day'
+);
+
+SET @query = IF(@col_exists = 0,
+    'ALTER TABLE contract_details ADD COLUMN work_on_day VARCHAR(255) AFTER work_off_day',
+    'SELECT "work_on_day already exists" AS Info'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ============================================
+-- 2. work_reports 테이블 동기화 (로컬용)
+-- ============================================
+-- 로컬에 없는 컬럼 추가 (EC2 기준으로 맞춤)
+
+-- work_report_context 컬럼이 없으면 추가
+SET @col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = 'buildup'
+    AND TABLE_NAME = 'work_reports'
+    AND COLUMN_NAME = 'work_report_context'
+);
+
+SET @query = IF(@col_exists = 0,
+    'ALTER TABLE work_reports ADD COLUMN work_report_context TEXT AFTER work_report_ended_at',
+    'SELECT "work_report_context already exists" AS Info'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- work_section_employee_num 컬럼이 없으면 추가
+SET @col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = 'buildup'
+    AND TABLE_NAME = 'work_reports'
+    AND COLUMN_NAME = 'work_section_employee_num'
+);
+
+SET @query = IF(@col_exists = 0,
+    'ALTER TABLE work_reports ADD COLUMN work_section_employee_num INT AFTER work_section_name',
+    'SELECT "work_section_employee_num already exists" AS Info'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ============================================
+-- 검증 쿼리
+-- ============================================
+
+SELECT '=== 스키마 동기화 완료 ===' AS Status;
+
+-- contract_details 컬럼 수 확인 (33개여야 함)
+SELECT
+    'contract_details' AS 'Table',
+    COUNT(*) AS 'Column Count (Expected: 33)'
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'buildup' AND TABLE_NAME = 'contract_details';
+
+-- work_reports 컬럼 수 확인 (18개여야 함)
+SELECT
+    'work_reports' AS 'Table',
+    COUNT(*) AS 'Column Count (Expected: 18)'
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'buildup' AND TABLE_NAME = 'work_reports';
+
+SELECT '=== 동기화 후 두 DB의 스키마가 동일해야 합니다 ===' AS Note;

--- a/src/main/java/com/concrete/buildup/domain/contract/repository/ContractRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/contract/repository/ContractRepository.java
@@ -128,6 +128,16 @@ public interface ContractRepository extends JpaRepository<Contract, Long>, Contr
     Optional<Contract> findByIdWithDetails(@Param("contractId") Long contractId);
 
     /**
+     * 계약 ID 목록으로 계약 + 상세 정보 일괄 조회 (Fetch Join)
+     * N+1 문제 방지를 위해 ContractDetail을 함께 조회
+     *
+     * @param contractIds 계약 ID 목록
+     * @return 계약 + 상세 정보 목록
+     */
+    @Query("SELECT c FROM Contract c LEFT JOIN FETCH c.contractDetail WHERE c.id IN :contractIds")
+    List<Contract> findByIdInWithDetails(@Param("contractIds") List<Long> contractIds);
+
+    /**
      * 근로자 ID로 계약 목록 + 상세 정보 조회 (Fetch Join, 페이징)
      * N+1 문제 방지를 위해 ContractDetail을 함께 조회
      *

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/controller/SafetyEducationController.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/controller/SafetyEducationController.java
@@ -141,6 +141,10 @@ public class SafetyEducationController {
 
                     ## 정렬
                     - 최신순 정렬 (생성일시 기준 내림차순)
+
+                    ## 필터링
+                    - year와 month를 함께 제공하면 해당 연도/월의 데이터만 조회됩니다.
+                    - 예: year=2025&month=11 → 2025년 11월 데이터만 조회
                     """
     )
     @ApiResponses({
@@ -175,10 +179,14 @@ public class SafetyEducationController {
     public ResponseEntity<ApiResponse<List<SafetyEducationLogListResponse>>> getSafetyEducationLogs(
             @Parameter(description = "현장 ID", required = true, example = "1")
             @PathVariable Long siteId,
+            @Parameter(description = "연도 (선택)", example = "2025")
+            @RequestParam(required = false) Integer year,
+            @Parameter(description = "월 (1-12, 선택)", example = "11")
+            @RequestParam(required = false) Integer month,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         List<SafetyEducationLogListResponse> response = safetyEducationService.getSafetyEducationLogs(
-                siteId, userDetails.getUsername()
+                siteId, year, month, userDetails.getUsername()
         );
         return ResponseEntity.ok(ApiResponse.success(response, "안전교육일지 목록을 조회했습니다."));
     }

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/controller/SafetyEducationController.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/controller/SafetyEducationController.java
@@ -13,8 +13,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +28,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/v1/{siteId}/safety-education-logs")
 @RequiredArgsConstructor
+@Validated
 public class SafetyEducationController {
 
     private final SafetyEducationService safetyEducationService;
@@ -182,7 +186,7 @@ public class SafetyEducationController {
             @Parameter(description = "연도 (선택)", example = "2025")
             @RequestParam(required = false) Integer year,
             @Parameter(description = "월 (1-12, 선택)", example = "11")
-            @RequestParam(required = false) Integer month,
+            @RequestParam(required = false) @Min(value = 1, message = "월은 1 이상이어야 합니다") @Max(value = 12, message = "월은 12 이하여야 합니다") Integer month,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         List<SafetyEducationLogListResponse> response = safetyEducationService.getSafetyEducationLogs(

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
@@ -51,6 +51,20 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
     List<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId);
 
     /**
+     * 현장별 안전교육일지가 있는 날짜 목록 조회 (연도/월 필터링, 중복 제거)
+     */
+    @Query("SELECT DISTINCT CAST(s.createdAt AS LocalDate) FROM SafetyEducationLog s " +
+            "WHERE s.site.id = :siteId " +
+            "AND YEAR(s.createdAt) = :year " +
+            "AND MONTH(s.createdAt) = :month " +
+            "AND s.isDeleted = false " +
+            "ORDER BY CAST(s.createdAt AS LocalDate) DESC")
+    List<LocalDate> findDistinctDatesBySiteIdAndYearMonth(
+            @Param("siteId") Long siteId,
+            @Param("year") int year,
+            @Param("month") int month);
+
+    /**
      * 현장별, 날짜별 안전교육일지 조회 (페이지네이션 지원)
      *
      * @param siteId 현장 ID
@@ -67,4 +81,23 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
             @Param("siteId") Long siteId,
             @Param("date") LocalDate date,
             Pageable pageable);
+
+    /**
+     * 현장별 안전교육일지 목록 조회 (연도/월 필터링)
+     *
+     * @param siteId 현장 ID
+     * @param year 연도
+     * @param month 월 (1-12)
+     * @return 안전교육일지 목록 (createdAt 내림차순)
+     */
+    @Query("SELECT s FROM SafetyEducationLog s " +
+            "WHERE s.site.id = :siteId " +
+            "AND YEAR(s.createdAt) = :year " +
+            "AND MONTH(s.createdAt) = :month " +
+            "AND s.isDeleted = false " +
+            "ORDER BY s.createdAt DESC")
+    List<SafetyEducationLog> findBySiteIdAndYearMonth(
+            @Param("siteId") Long siteId,
+            @Param("year") int year,
+            @Param("month") int month);
 }

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/repository/SafetyEducationLogRepository.java
@@ -55,14 +55,14 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
      */
     @Query("SELECT DISTINCT CAST(s.createdAt AS LocalDate) FROM SafetyEducationLog s " +
             "WHERE s.site.id = :siteId " +
-            "AND YEAR(s.createdAt) = :year " +
-            "AND MONTH(s.createdAt) = :month " +
+            "AND s.createdAt >= :startDate " +
+            "AND s.createdAt < :endDate " +
             "AND s.isDeleted = false " +
             "ORDER BY CAST(s.createdAt AS LocalDate) DESC")
     List<LocalDate> findDistinctDatesBySiteIdAndYearMonth(
             @Param("siteId") Long siteId,
-            @Param("year") int year,
-            @Param("month") int month);
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
 
     /**
      * 현장별, 날짜별 안전교육일지 조회 (페이지네이션 지원)
@@ -86,18 +86,18 @@ public interface SafetyEducationLogRepository extends JpaRepository<SafetyEducat
      * 현장별 안전교육일지 목록 조회 (연도/월 필터링)
      *
      * @param siteId 현장 ID
-     * @param year 연도
-     * @param month 월 (1-12)
+     * @param startDate 시작 날짜 (해당 월의 1일 00:00:00)
+     * @param endDate 종료 날짜 (다음 월의 1일 00:00:00)
      * @return 안전교육일지 목록 (createdAt 내림차순)
      */
     @Query("SELECT s FROM SafetyEducationLog s " +
             "WHERE s.site.id = :siteId " +
-            "AND YEAR(s.createdAt) = :year " +
-            "AND MONTH(s.createdAt) = :month " +
+            "AND s.createdAt >= :startDate " +
+            "AND s.createdAt < :endDate " +
             "AND s.isDeleted = false " +
             "ORDER BY s.createdAt DESC")
     List<SafetyEducationLog> findBySiteIdAndYearMonth(
             @Param("siteId") Long siteId,
-            @Param("year") int year,
-            @Param("month") int month);
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
@@ -121,7 +121,22 @@ public class SafetyEducationService {
                 .build();
     }
 
-    public List<SafetyEducationLogListResponse> getSafetyEducationLogs(Long siteId, String currentUserId) {
+    /**
+     * 현장별 안전교육일지 목록 조회
+     *
+     * <p>연도/월 필터링 옵션을 지원합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param year 연도 (선택)
+     * @param month 월 (선택, 1-12)
+     * @param currentUserId 현재 로그인한 사용자 ID
+     * @return 안전교육일지 목록
+     */
+    public List<SafetyEducationLogListResponse> getSafetyEducationLogs(
+            Long siteId,
+            Integer year,
+            Integer month,
+            String currentUserId) {
         // Site 존재 여부 검증
         Site site = siteRepository.findById(siteId)
                 .orElseThrow(() -> new BusinessException(SafetyDocErrorCode.SITE_NOT_FOUND));
@@ -129,8 +144,15 @@ public class SafetyEducationService {
         // 권한 검증
         validateManagerAuthorization(site, currentUserId);
 
-        List<SafetyEducationLog> logs = safetyEducationLogRepository
-                .findBySiteIdAndIsDeletedFalseOrderByCreatedAtDesc(siteId);
+        // 안전교육일지 목록 조회
+        List<SafetyEducationLog> logs;
+        if (year != null && month != null) {
+            // 연도/월 필터링
+            logs = safetyEducationLogRepository.findBySiteIdAndYearMonth(siteId, year, month);
+        } else {
+            // 전체 조회
+            logs = safetyEducationLogRepository.findBySiteIdAndIsDeletedFalseOrderByCreatedAtDesc(siteId);
+        }
 
         return logs.stream()
                 .map(log -> {

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
@@ -147,8 +147,10 @@ public class SafetyEducationService {
         // 안전교육일지 목록 조회
         List<SafetyEducationLog> logs;
         if (year != null && month != null) {
-            // 연도/월 필터링
-            logs = safetyEducationLogRepository.findBySiteIdAndYearMonth(siteId, year, month);
+            // 연도/월 필터링 - LocalDateTime 범위로 변환
+            LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0);
+            LocalDateTime endDate = startDate.plusMonths(1);
+            logs = safetyEducationLogRepository.findBySiteIdAndYearMonth(siteId, startDate, endDate);
         } else {
             // 전체 조회
             logs = safetyEducationLogRepository.findBySiteIdAndIsDeletedFalseOrderByCreatedAtDesc(siteId);

--- a/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
+++ b/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
@@ -197,6 +197,10 @@ public class SiteController {
                     - 날짜별 작업일보 (ID, 순번)
 
                     **정렬:** 최신 날짜순 (내림차순)
+
+                    **필터링:**
+                    - year와 month를 함께 제공하면 해당 연도/월의 데이터만 조회됩니다.
+                    - 예: year=2025&month=11 → 2025년 11월 데이터만 조회
                     """
     )
     @ApiResponses({
@@ -253,13 +257,17 @@ public class SiteController {
     public ResponseEntity<ApiResponse<SafetyWorkDocumentListResponse>> getSafetyWorkDocuments(
             @Parameter(description = "현장 ID", required = true, example = "1")
             @PathVariable Long siteId,
+            @Parameter(description = "연도 (선택)", example = "2025")
+            @RequestParam(required = false) Integer year,
+            @Parameter(description = "월 (1-12, 선택)", example = "11")
+            @RequestParam(required = false) Integer month,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        log.info("안전/작업 문서 목록 조회 API 호출: siteId={}, page={}, size={}",
-                siteId, pageable.getPageNumber(), pageable.getPageSize());
+        log.info("안전/작업 문서 목록 조회 API 호출: siteId={}, year={}, month={}, page={}, size={}",
+                siteId, year, month, pageable.getPageNumber(), pageable.getPageSize());
 
-        SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+        SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, year, month, pageable);
 
         log.info("안전/작업 문서 목록 조회 완료: siteId={}, totalElements={}", siteId, response.getTotalElements());
 

--- a/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
+++ b/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
@@ -1,10 +1,12 @@
 package com.concrete.buildup.domain.site.controller;
 
+import com.concrete.buildup.domain.site.dto.DashboardResponse;
 import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentListResponse;
 import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
 import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
 import com.concrete.buildup.domain.site.dto.SiteDetailResponse;
 import com.concrete.buildup.domain.site.dto.SiteListResponse;
+import com.concrete.buildup.domain.site.service.DashboardService;
 import com.concrete.buildup.domain.site.service.SiteService;
 import com.concrete.buildup.global.common.ApiResponse;
 import com.concrete.buildup.global.util.MaskingUtil;
@@ -40,6 +42,7 @@ import org.springframework.web.bind.annotation.*;
 public class SiteController {
 
     private final SiteService siteService;
+    private final DashboardService dashboardService;
 
     /**
      * 현장 등록 API
@@ -262,6 +265,109 @@ public class SiteController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(response, "안전/작업 문서 목록을 조회했습니다.")
+        );
+    }
+
+    /**
+     * 현장 대시보드 조회 API
+     *
+     * <p>기업 관리자와 현장 관리자가 현장의 대시보드 정보를 조회합니다.</p>
+     * <p>현장 기본 정보, 인원 현황, 안전 현황, 노무 현황을 포함합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @return DashboardResponse - 대시보드 정보
+     */
+    @Operation(
+            summary = "현장 대시보드 조회",
+            description = """
+                    현장의 대시보드 정보를 조회합니다.
+
+                    **포함 정보:**
+                    - 현장 기본 정보: 현장명, 주소, 발주처, 공사 기간, 진행률, 관리자 이름
+                    - 인원 현황: 총 근로자 수, 상용직/일용직 수, 금일 출근 인원, 금일 지각 인원
+                    - 안전 현황: 안전율, 금일 안전 경고, 교육 미이수 인원, 안전점검 완료 건수
+                    - 노무 현황: 미결 전자계약 수, 미결 계약 목록 (근로계약서, 안전교육일지)
+
+                    **사용 시나리오:**
+                    - 기업 관리자: 왼쪽 사이드바에서 현장 선택 후 대시보드 확인
+                    - 현장 관리자: 자신이 담당하는 현장의 대시보드 확인
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "message": "대시보드 정보를 성공적으로 조회했습니다.",
+                                      "data": {
+                                        "siteInfo": {
+                                          "siteId": 1,
+                                          "siteName": "강남 오피스텔 신축현장",
+                                          "siteAddress": "서울특별시 강남구 역삼동 123-45",
+                                          "clientName": "서울시설공단",
+                                          "startDate": "2025-01-01",
+                                          "endDate": "2025-12-31",
+                                          "progressRate": 45.5,
+                                          "managerName": "김현장"
+                                        },
+                                        "workforceStatus": {
+                                          "totalWorkers": 50,
+                                          "permanentWorkers": 30,
+                                          "dailyWorkers": 20,
+                                          "todayAttendance": 45,
+                                          "todayLateCount": 3
+                                        },
+                                        "safetyStatus": {
+                                          "safetyRate": 92.5,
+                                          "todayWarnings": 2,
+                                          "incompletedEducation": 5,
+                                          "completedInspections": 10
+                                        },
+                                        "laborStatus": {
+                                          "totalPendingContracts": 3,
+                                          "pendingContracts": [
+                                            {
+                                              "contractId": 101,
+                                              "contractType": "근로계약서",
+                                              "targetName": "김철수",
+                                              "contractState": "MANAGER_SIGNING_PENDING"
+                                            },
+                                            {
+                                              "contractId": 15,
+                                              "contractType": "안전교육일지",
+                                              "targetName": "추락 재해 예방 교육",
+                                              "contractState": "MANAGER_SIGNING_PENDING"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "현장을 찾을 수 없음"
+            )
+    })
+    @GetMapping("/{siteId}/dashboard")
+    @PreAuthorize("hasAnyRole('MANAGER', 'CORPORATION')")
+    public ResponseEntity<ApiResponse<DashboardResponse>> getDashboard(
+            @Parameter(description = "현장 ID", required = true, example = "1")
+            @PathVariable Long siteId
+    ) {
+        log.info("대시보드 조회 API 호출: siteId={}", siteId);
+
+        DashboardResponse response = dashboardService.getDashboard(siteId);
+
+        log.info("대시보드 조회 완료: siteId={}", siteId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "대시보드 정보를 성공적으로 조회했습니다.")
         );
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
+++ b/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
@@ -17,9 +17,12 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +41,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/v1/sites")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "Site", description = "현장 관리 API")
 public class SiteController {
 
@@ -260,7 +264,7 @@ public class SiteController {
             @Parameter(description = "연도 (선택)", example = "2025")
             @RequestParam(required = false) Integer year,
             @Parameter(description = "월 (1-12, 선택)", example = "11")
-            @RequestParam(required = false) Integer month,
+            @RequestParam(required = false) @Min(value = 1, message = "월은 1 이상이어야 합니다") @Max(value = 12, message = "월은 12 이하여야 합니다") Integer month,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @PageableDefault(size = 20) Pageable pageable
     ) {

--- a/src/main/java/com/concrete/buildup/domain/site/dto/DashboardResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/site/dto/DashboardResponse.java
@@ -1,0 +1,149 @@
+package com.concrete.buildup.domain.site.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 대시보드(홈) 화면 응답 DTO
+ *
+ * <p>기업 관리자와 현장 관리자에게 현장 관리 정보를 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@Schema(description = "대시보드 응답 DTO")
+public class DashboardResponse {
+
+    @Schema(description = "현장 기본 정보")
+    private SiteBasicInfo siteInfo;
+
+    @Schema(description = "인원 현황")
+    private WorkforceStatus workforceStatus;
+
+    @Schema(description = "안전 현황")
+    private SafetyStatus safetyStatus;
+
+    @Schema(description = "노무 현황")
+    private LaborStatus laborStatus;
+
+    /**
+     * 현장 기본 정보
+     */
+    @Getter
+    @Builder
+    @Schema(description = "현장 기본 정보")
+    public static class SiteBasicInfo {
+
+        @Schema(description = "현장 ID", example = "1")
+        private Long siteId;
+
+        @Schema(description = "현장명", example = "강남 오피스텔 신축현장")
+        private String siteName;
+
+        @Schema(description = "현장 주소", example = "서울특별시 강남구 역삼동 123-45")
+        private String siteAddress;
+
+        @Schema(description = "발주처", example = "서울시설공단")
+        private String clientName;
+
+        @Schema(description = "시작일", example = "2025-01-01")
+        private LocalDate startDate;
+
+        @Schema(description = "종료일", example = "2025-12-31")
+        private LocalDate endDate;
+
+        @Schema(description = "진행률 (0.0 ~ 100.0)", example = "45.5")
+        private BigDecimal progressRate;
+
+        @Schema(description = "현장 관리자 이름", example = "김현장")
+        private String managerName;
+    }
+
+    /**
+     * 인원 현황
+     */
+    @Getter
+    @Builder
+    @Schema(description = "인원 현황")
+    public static class WorkforceStatus {
+
+        @Schema(description = "총 근로자 수", example = "50")
+        private Integer totalWorkers;
+
+        @Schema(description = "상용직 수", example = "30")
+        private Integer permanentWorkers;
+
+        @Schema(description = "일용직 수", example = "20")
+        private Integer dailyWorkers;
+
+        @Schema(description = "금일 출근 인원 수", example = "45")
+        private Integer todayAttendance;
+
+        @Schema(description = "금일 지각 인원 수", example = "3")
+        private Integer todayLateCount;
+    }
+
+    /**
+     * 안전 현황
+     */
+    @Getter
+    @Builder
+    @Schema(description = "안전 현황")
+    public static class SafetyStatus {
+
+        @Schema(description = "안전율 (0.0 ~ 100.0)", example = "92.5")
+        private BigDecimal safetyRate;
+
+        @Schema(description = "금일 발생 안전 경고 건수", example = "2")
+        private Integer todayWarnings;
+
+        @Schema(description = "교육 미이수 인원 수", example = "5")
+        private Integer incompletedEducation;
+
+        @Schema(description = "안전점검 완료 건수", example = "10")
+        private Integer completedInspections;
+    }
+
+    /**
+     * 노무 현황
+     */
+    @Getter
+    @Builder
+    @Schema(description = "노무 현황")
+    public static class LaborStatus {
+
+        @Schema(description = "전체 미결 전자계약 수", example = "3")
+        private Integer totalPendingContracts;
+
+        @Schema(description = "미결 전자계약 목록")
+        private List<PendingContractItem> pendingContracts;
+    }
+
+    /**
+     * 미결 전자계약 항목
+     */
+    @Getter
+    @Builder
+    @Schema(description = "미결 전자계약 항목")
+    public static class PendingContractItem {
+
+        @Schema(description = "계약 ID", example = "101")
+        private Long contractId;
+
+        @Schema(description = "계약서 종류 (근로계약서 또는 안전교육일지)", example = "근로계약서")
+        private String contractType;
+
+        @Schema(description = "대상자 이름", example = "김철수")
+        private String targetName;
+
+        @Schema(description = "계약 상태 (MANAGER_SIGNING_PENDING, EMPLOYEE_SIGNING_PENDING 등)", example = "MANAGER_SIGNING_PENDING")
+        private String contractState;
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/service/DashboardService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/DashboardService.java
@@ -263,31 +263,23 @@ public class DashboardService {
      * workStartTime + 5분 이후 출근한 인원
      */
     private int calculateTodayLateCount(List<AttendanceRecord> attendanceRecords, List<Contract> contracts) {
-        // Contract의 employeeId -> Contract 매핑
-        Map<Long, Contract> contractMap = contracts.stream()
-            .collect(Collectors.toMap(
-                Contract::getEmployeeId,
-                contract -> contract,
-                (existing, replacement) -> existing // 중복 시 기존 값 유지
-            ));
-
-        // ContractDetail을 포함한 Contract를 조회
+        // ContractDetail을 포함한 Contract를 일괄 조회 (N+1 문제 해결)
         List<Long> contractIds = contracts.stream()
             .map(Contract::getId)
+            .distinct()
             .collect(Collectors.toList());
 
         if (contractIds.isEmpty()) {
             return 0;
         }
 
-        Map<Long, Contract> contractWithDetailsMap = contractIds.stream()
-            .map(id -> contractRepository.findByIdWithDetails(id))
-            .filter(opt -> opt.isPresent())
-            .map(opt -> opt.get())
+        // 일괄 조회로 N+1 문제 해결
+        Map<Long, Contract> contractWithDetailsMap = contractRepository.findByIdInWithDetails(contractIds)
+            .stream()
             .collect(Collectors.toMap(
                 Contract::getEmployeeId,
                 contract -> contract,
-                (existing, replacement) -> existing
+                (existing, replacement) -> existing // 중복 시 기존 값 유지
             ));
 
         int lateCount = 0;

--- a/src/main/java/com/concrete/buildup/domain/site/service/DashboardService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/DashboardService.java
@@ -1,0 +1,401 @@
+package com.concrete.buildup.domain.site.service;
+
+import com.concrete.buildup.domain.attendance.entity.AttendanceRecord;
+import com.concrete.buildup.domain.attendance.enums.AttendanceState;
+import com.concrete.buildup.domain.attendance.enums.AttendanceType;
+import com.concrete.buildup.domain.attendance.repository.AttendanceRecordRepository;
+import com.concrete.buildup.domain.auth.entity.Employee;
+import com.concrete.buildup.domain.auth.entity.Manager;
+import com.concrete.buildup.domain.auth.repository.EmployeeRepository;
+import com.concrete.buildup.domain.contract.entity.Contract;
+import com.concrete.buildup.domain.contract.enums.ContractState;
+import com.concrete.buildup.domain.contract.repository.ContractRepository;
+import com.concrete.buildup.domain.safetydoc.entity.SafetyEducationLog;
+import com.concrete.buildup.domain.safetydoc.enums.SafetyEducationStatus;
+import com.concrete.buildup.domain.safetydoc.repository.SafetyEducationLogRepository;
+import com.concrete.buildup.domain.site.dto.DashboardResponse;
+import com.concrete.buildup.domain.site.entity.Site;
+import com.concrete.buildup.domain.site.repository.SiteRepository;
+import com.concrete.buildup.global.exception.BusinessException;
+import com.concrete.buildup.global.exception.errorcode.SiteErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 대시보드 서비스
+ *
+ * <p>현장 대시보드 정보를 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class DashboardService {
+
+    private final SiteRepository siteRepository;
+    private final ContractRepository contractRepository;
+    private final EmployeeRepository employeeRepository;
+    private final AttendanceRecordRepository attendanceRecordRepository;
+    private final SafetyEducationLogRepository safetyEducationLogRepository;
+
+    /**
+     * 현장 대시보드 조회
+     *
+     * <p>기업 관리자와 현장 관리자 공통 API</p>
+     *
+     * @param siteId 현장 ID
+     * @return 대시보드 정보
+     */
+    public DashboardResponse getDashboard(Long siteId) {
+        log.info("대시보드 조회 시작 - siteId: {}", siteId);
+
+        // 현장 정보 조회 (Manager 정보 포함)
+        Site site = siteRepository.findByIdWithManager(siteId)
+            .orElseThrow(() -> new BusinessException(SiteErrorCode.SITE_NOT_FOUND));
+
+        Manager manager = site.getManager();
+        Long managerId = manager != null ? manager.getId() : null;
+
+        // 1. 현장 기본 정보
+        DashboardResponse.SiteBasicInfo siteInfo = buildSiteBasicInfo(site);
+
+        // 2. 인원 현황
+        DashboardResponse.WorkforceStatus workforceStatus = buildWorkforceStatus(siteId, managerId);
+
+        // 3. 안전 현황 (임의 값)
+        DashboardResponse.SafetyStatus safetyStatus = buildSafetyStatus();
+
+        // 4. 노무 현황
+        DashboardResponse.LaborStatus laborStatus = buildLaborStatus(siteId, managerId);
+
+        log.info("대시보드 조회 완료 - siteId: {}", siteId);
+
+        return DashboardResponse.builder()
+            .siteInfo(siteInfo)
+            .workforceStatus(workforceStatus)
+            .safetyStatus(safetyStatus)
+            .laborStatus(laborStatus)
+            .build();
+    }
+
+    /**
+     * 현장 기본 정보 구성
+     */
+    private DashboardResponse.SiteBasicInfo buildSiteBasicInfo(Site site) {
+        // 진행률 계산 (시작일 ~ 종료일 기준)
+        BigDecimal progressRate = calculateProgressRate(site.getStartDate(), site.getEndDate());
+
+        String managerName = null;
+        if (site.getManager() != null) {
+            managerName = site.getManager().getManagerName();
+        }
+
+        return DashboardResponse.SiteBasicInfo.builder()
+            .siteId(site.getId())
+            .siteName(site.getSiteName())
+            .siteAddress(site.getSiteAddress())
+            .clientName(site.getClientName())
+            .startDate(site.getStartDate())
+            .endDate(site.getEndDate())
+            .progressRate(progressRate)
+            .managerName(managerName)
+            .build();
+    }
+
+    /**
+     * 진행률 계산
+     * (오늘 - 시작일) / (종료일 - 시작일) * 100
+     */
+    private BigDecimal calculateProgressRate(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            return BigDecimal.ZERO;
+        }
+
+        LocalDate today = LocalDate.now();
+
+        // 시작 전
+        if (today.isBefore(startDate)) {
+            return BigDecimal.ZERO;
+        }
+
+        // 종료 후
+        if (today.isAfter(endDate)) {
+            return BigDecimal.valueOf(100);
+        }
+
+        // 진행 중
+        long totalDays = ChronoUnit.DAYS.between(startDate, endDate);
+        long elapsedDays = ChronoUnit.DAYS.between(startDate, today);
+
+        if (totalDays == 0) {
+            return BigDecimal.valueOf(100);
+        }
+
+        return BigDecimal.valueOf(elapsedDays)
+            .multiply(BigDecimal.valueOf(100))
+            .divide(BigDecimal.valueOf(totalDays), 1, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 인원 현황 구성
+     */
+    private DashboardResponse.WorkforceStatus buildWorkforceStatus(Long siteId, Long managerId) {
+        if (managerId == null) {
+            // Manager가 없는 경우 0으로 반환
+            return DashboardResponse.WorkforceStatus.builder()
+                .totalWorkers(0)
+                .permanentWorkers(0)
+                .dailyWorkers(0)
+                .todayAttendance(0)
+                .todayLateCount(0)
+                .build();
+        }
+
+        // 해당 현장(Manager)의 모든 활성 계약 조회
+        LocalDate today = LocalDate.now();
+        List<Contract> activeContracts = contractRepository.findByManagerId(managerId, Pageable.unpaged())
+            .getContent()
+            .stream()
+            .filter(contract -> contract.getContractState() == ContractState.FULLY_SIGNED)
+            .filter(contract -> isContractActiveOnDate(contract, today))
+            .collect(Collectors.toList());
+
+        // 근로자 ID 목록
+        List<Long> employeeIds = activeContracts.stream()
+            .map(Contract::getEmployeeId)
+            .distinct()
+            .collect(Collectors.toList());
+
+        if (employeeIds.isEmpty()) {
+            return DashboardResponse.WorkforceStatus.builder()
+                .totalWorkers(0)
+                .permanentWorkers(0)
+                .dailyWorkers(0)
+                .todayAttendance(0)
+                .todayLateCount(0)
+                .build();
+        }
+
+        // 근로자 조회
+        List<Employee> employees = employeeRepository.findAllById(employeeIds);
+
+        // 총 근로자 수
+        int totalWorkers = employees.size();
+
+        // 상용직/일용직 구분
+        Map<String, Long> empTypeCount = employees.stream()
+            .collect(Collectors.groupingBy(
+                emp -> emp.getEmpType() != null ? emp.getEmpType() : "UNKNOWN",
+                Collectors.counting()
+            ));
+
+        int permanentWorkers = empTypeCount.getOrDefault("PERMANENT", 0L).intValue();
+        int dailyWorkers = empTypeCount.getOrDefault("DAILY", 0L).intValue();
+
+        // 금일 출근 인원 (AttendanceRecord에서 CHECK_IN, CONFIRMED 상태)
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        List<AttendanceRecord> todayAttendanceRecords = attendanceRecordRepository
+            .findBySiteIdAndTimestampBetween(siteId, startOfDay, endOfDay, Pageable.unpaged())
+            .getContent()
+            .stream()
+            .filter(record -> record.getAttendanceType() == AttendanceType.CHECK_IN)
+            .filter(record -> record.getState() == AttendanceState.CONFIRMED)
+            .collect(Collectors.toList());
+
+        int todayAttendance = (int) todayAttendanceRecords.stream()
+            .map(AttendanceRecord::getEmployeeId)
+            .distinct()
+            .count();
+
+        // 금일 지각 인원 계산
+        int todayLateCount = calculateTodayLateCount(todayAttendanceRecords, activeContracts);
+
+        return DashboardResponse.WorkforceStatus.builder()
+            .totalWorkers(totalWorkers)
+            .permanentWorkers(permanentWorkers)
+            .dailyWorkers(dailyWorkers)
+            .todayAttendance(todayAttendance)
+            .todayLateCount(todayLateCount)
+            .build();
+    }
+
+    /**
+     * 계약이 특정 날짜에 활성 상태인지 확인
+     */
+    private boolean isContractActiveOnDate(Contract contract, LocalDate date) {
+        LocalDate startDate = contract.getEmployeeStartDate();
+        LocalDate endDate = contract.getEmployeeEndDate();
+
+        if (startDate == null) {
+            return false;
+        }
+
+        // 시작일 <= 날짜
+        if (date.isBefore(startDate)) {
+            return false;
+        }
+
+        // 종료일이 없거나 종료일 >= 날짜
+        return endDate == null || !date.isAfter(endDate);
+    }
+
+    /**
+     * 금일 지각 인원 계산
+     * workStartTime + 5분 이후 출근한 인원
+     */
+    private int calculateTodayLateCount(List<AttendanceRecord> attendanceRecords, List<Contract> contracts) {
+        // Contract의 employeeId -> Contract 매핑
+        Map<Long, Contract> contractMap = contracts.stream()
+            .collect(Collectors.toMap(
+                Contract::getEmployeeId,
+                contract -> contract,
+                (existing, replacement) -> existing // 중복 시 기존 값 유지
+            ));
+
+        // ContractDetail을 포함한 Contract를 조회
+        List<Long> contractIds = contracts.stream()
+            .map(Contract::getId)
+            .collect(Collectors.toList());
+
+        if (contractIds.isEmpty()) {
+            return 0;
+        }
+
+        Map<Long, Contract> contractWithDetailsMap = contractIds.stream()
+            .map(id -> contractRepository.findByIdWithDetails(id))
+            .filter(opt -> opt.isPresent())
+            .map(opt -> opt.get())
+            .collect(Collectors.toMap(
+                Contract::getEmployeeId,
+                contract -> contract,
+                (existing, replacement) -> existing
+            ));
+
+        int lateCount = 0;
+        for (AttendanceRecord record : attendanceRecords) {
+            Contract contract = contractWithDetailsMap.get(record.getEmployeeId());
+            if (contract == null || contract.getContractDetail() == null) {
+                continue;
+            }
+
+            LocalTime workStartTime = contract.getContractDetail().getWorkStartTime();
+            if (workStartTime == null) {
+                continue; // 출근 시간 정보 없음
+            }
+
+            // 지각 기준: workStartTime + 5분
+            LocalTime lateThreshold = workStartTime.plusMinutes(5);
+            LocalTime checkInTime = record.getTimestamp().toLocalTime();
+
+            if (checkInTime.isAfter(lateThreshold)) {
+                lateCount++;
+            }
+        }
+
+        return lateCount;
+    }
+
+    /**
+     * 안전 현황 구성 (임의 값)
+     */
+    private DashboardResponse.SafetyStatus buildSafetyStatus() {
+        // 안전 관련 지표는 계산이 어려운 경우 임의의 숫자로 대체 (요구사항)
+        return DashboardResponse.SafetyStatus.builder()
+            .safetyRate(BigDecimal.valueOf(92.5))
+            .todayWarnings(2)
+            .incompletedEducation(5)
+            .completedInspections(10)
+            .build();
+    }
+
+    /**
+     * 노무 현황 구성
+     */
+    private DashboardResponse.LaborStatus buildLaborStatus(Long siteId, Long managerId) {
+        List<DashboardResponse.PendingContractItem> pendingContracts = new ArrayList<>();
+
+        if (managerId != null) {
+            // 1. 미결 근로계약서 조회 (FULLY_SIGNED가 아닌 것)
+            List<Contract> pendingEmploymentContracts = contractRepository.findByManagerId(managerId, Pageable.unpaged())
+                .getContent()
+                .stream()
+                .filter(contract -> contract.getContractState() != ContractState.FULLY_SIGNED)
+                .filter(contract -> contract.getContractState() != ContractState.TERMINATED)
+                .collect(Collectors.toList());
+
+            // Employee 정보 조회
+            Map<Long, Employee> employeeMap = getEmployeeMap(
+                pendingEmploymentContracts.stream()
+                    .map(Contract::getEmployeeId)
+                    .collect(Collectors.toList())
+            );
+
+            for (Contract contract : pendingEmploymentContracts) {
+                Employee employee = employeeMap.get(contract.getEmployeeId());
+                String targetName = employee != null ? employee.getEmpName() : "알 수 없음";
+
+                pendingContracts.add(DashboardResponse.PendingContractItem.builder()
+                    .contractId(contract.getId())
+                    .contractType("근로계약서")
+                    .targetName(targetName)
+                    .contractState(contract.getContractState().name())
+                    .build());
+            }
+
+            // 2. 미결 안전교육일지 조회 (COMPLETED가 아닌 것)
+            List<SafetyEducationLog> pendingSafetyLogs = safetyEducationLogRepository
+                .findBySiteIdAndIsDeletedFalseOrderByCreatedAtDesc(siteId)
+                .stream()
+                .filter(log -> log.getStatus() != SafetyEducationStatus.COMPLETED)
+                .collect(Collectors.toList());
+
+            for (SafetyEducationLog log : pendingSafetyLogs) {
+                pendingContracts.add(DashboardResponse.PendingContractItem.builder()
+                    .contractId(log.getId())
+                    .contractType("안전교육일지")
+                    .targetName(log.getEducationSubject()) // 교육 과목을 대상자 이름으로 사용
+                    .contractState(log.getStatus().name())
+                    .build());
+            }
+        }
+
+        return DashboardResponse.LaborStatus.builder()
+            .totalPendingContracts(pendingContracts.size())
+            .pendingContracts(pendingContracts)
+            .build();
+    }
+
+    /**
+     * Employee ID 목록으로 Employee Map 생성
+     */
+    private Map<Long, Employee> getEmployeeMap(List<Long> employeeIds) {
+        if (employeeIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return employeeRepository.findAllById(employeeIds).stream()
+            .collect(Collectors.toMap(
+                employee -> employee.getId(),
+                employee -> employee
+            ));
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -207,9 +207,11 @@ public class SiteService {
         List<LocalDate> workReportDates;
 
         if (year != null && month != null) {
-            // 연도/월 필터링
-            safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteIdAndYearMonth(siteId, year, month);
-            workReportDates = workReportRepository.findDistinctDatesBySiteIdAndYearMonth(siteId, year, month);
+            // 연도/월 필터링 - LocalDateTime 범위로 변환
+            java.time.LocalDateTime startDate = java.time.LocalDateTime.of(year, month, 1, 0, 0);
+            java.time.LocalDateTime endDate = startDate.plusMonths(1);
+            safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteIdAndYearMonth(siteId, startDate, endDate);
+            workReportDates = workReportRepository.findDistinctDatesBySiteIdAndYearMonth(siteId, startDate, endDate);
         } else {
             // 전체 조회
             safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteId(siteId);

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -181,14 +181,21 @@ public class SiteService {
      *
      * <p>날짜별로 안전교육일지와 작업일보를 통합하여 조회합니다.</p>
      * <p>페이지네이션을 지원하며, 최신 날짜순으로 정렬됩니다.</p>
+     * <p>연도/월 필터링 옵션을 지원합니다.</p>
      *
      * @param siteId 현장 ID
+     * @param year 연도 (선택)
+     * @param month 월 (선택, 1-12)
      * @param pageable 페이지네이션 정보
      * @return 날짜별 안전/작업 문서 목록
      */
-    public SafetyWorkDocumentListResponse getSafetyWorkDocuments(Long siteId, Pageable pageable) {
-        log.info("안전/작업 문서 목록 조회 - siteId: {}, page: {}, size: {}",
-                siteId, pageable.getPageNumber(), pageable.getPageSize());
+    public SafetyWorkDocumentListResponse getSafetyWorkDocuments(
+            Long siteId,
+            Integer year,
+            Integer month,
+            Pageable pageable) {
+        log.info("안전/작업 문서 목록 조회 - siteId: {}, year: {}, month: {}, page: {}, size: {}",
+                siteId, year, month, pageable.getPageNumber(), pageable.getPageSize());
 
         // 현장 존재 여부 확인
         if (!siteRepository.existsById(siteId)) {
@@ -196,8 +203,18 @@ public class SiteService {
         }
 
         // 두 테이블에서 전체 날짜 목록 조회 (페이지네이션 없이)
-        List<LocalDate> safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteId(siteId);
-        List<LocalDate> workReportDates = workReportRepository.findDistinctDatesBySiteId(siteId);
+        List<LocalDate> safetyDates;
+        List<LocalDate> workReportDates;
+
+        if (year != null && month != null) {
+            // 연도/월 필터링
+            safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteIdAndYearMonth(siteId, year, month);
+            workReportDates = workReportRepository.findDistinctDatesBySiteIdAndYearMonth(siteId, year, month);
+        } else {
+            // 전체 조회
+            safetyDates = safetyEducationLogRepository.findDistinctDatesBySiteId(siteId);
+            workReportDates = workReportRepository.findDistinctDatesBySiteId(siteId);
+        }
 
         // 날짜 병합 및 정렬
         Set<LocalDate> allDates = new HashSet<>();

--- a/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -155,7 +157,7 @@ public class WorkReportController {
             @Parameter(description = "연도 (선택)", example = "2025")
             @RequestParam(required = false) Integer year,
             @Parameter(description = "월 (1-12, 선택)", example = "11")
-            @RequestParam(required = false) Integer month,
+            @RequestParam(required = false) @Min(value = 1, message = "월은 1 이상이어야 합니다") @Max(value = 12, message = "월은 12 이하여야 합니다") Integer month,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @PageableDefault(size = 20) Pageable pageable
     ) {

--- a/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/controller/WorkReportController.java
@@ -130,6 +130,10 @@ public class WorkReportController {
                 - 작성자 이름
 
                 **정렬:** 최신 작성일순 (내림차순)
+
+                **필터링:**
+                - year와 month를 함께 제공하면 해당 연도/월의 데이터만 조회됩니다.
+                - 예: year=2025&month=11 → 2025년 11월 데이터만 조회
                 """
     )
     @ApiResponses({
@@ -148,13 +152,17 @@ public class WorkReportController {
     public ResponseEntity<ApiResponse<WorkReportListResponse>> getWorkReportList(
             @Parameter(description = "현장 ID", required = true, example = "1")
             @PathVariable Long siteId,
+            @Parameter(description = "연도 (선택)", example = "2025")
+            @RequestParam(required = false) Integer year,
+            @Parameter(description = "월 (1-12, 선택)", example = "11")
+            @RequestParam(required = false) Integer month,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        log.info("작업일보 목록 조회 API 호출: siteId={}, page={}, size={}",
-                siteId, pageable.getPageNumber(), pageable.getPageSize());
+        log.info("작업일보 목록 조회 API 호출: siteId={}, year={}, month={}, page={}, size={}",
+                siteId, year, month, pageable.getPageNumber(), pageable.getPageSize());
 
-        WorkReportListResponse response = workReportService.getWorkReportList(siteId, pageable);
+        WorkReportListResponse response = workReportService.getWorkReportList(siteId, year, month, pageable);
 
         log.info("작업일보 목록 조회 완료: siteId={}, totalElements={}", siteId, response.getTotalElements());
 

--- a/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
@@ -54,6 +54,20 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
     List<LocalDate> findDistinctDatesBySiteId(@Param("siteId") Long siteId);
 
     /**
+     * 현장별 작업일보가 있는 날짜 목록 조회 (연도/월 필터링, 중복 제거)
+     */
+    @Query("SELECT DISTINCT CAST(w.createdAt AS LocalDate) FROM WorkReport w " +
+            "WHERE w.site.id = :siteId " +
+            "AND YEAR(w.createdAt) = :year " +
+            "AND MONTH(w.createdAt) = :month " +
+            "AND w.isDeleted = false " +
+            "ORDER BY CAST(w.createdAt AS LocalDate) DESC")
+    List<LocalDate> findDistinctDatesBySiteIdAndYearMonth(
+            @Param("siteId") Long siteId,
+            @Param("year") int year,
+            @Param("month") int month);
+
+    /**
      * 현장별, 날짜별 작업일보 조회 (페이지네이션 지원)
      *
      * @param siteId 현장 ID
@@ -84,4 +98,26 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
             "AND w.isDeleted = false " +
             "ORDER BY w.createdAt DESC")
     Page<WorkReport> findBySiteIdWithManager(@Param("siteId") Long siteId, Pageable pageable);
+
+    /**
+     * 현장별 작업일보 목록 조회 (연도/월 필터링, 페이지네이션 지원, Manager fetch join)
+     *
+     * @param siteId 현장 ID
+     * @param year 연도
+     * @param month 월 (1-12)
+     * @param pageable 페이지네이션 정보
+     * @return 작업일보 페이지 (createdAt 내림차순)
+     */
+    @Query("SELECT w FROM WorkReport w " +
+            "JOIN FETCH w.manager m " +
+            "WHERE w.site.id = :siteId " +
+            "AND YEAR(w.createdAt) = :year " +
+            "AND MONTH(w.createdAt) = :month " +
+            "AND w.isDeleted = false " +
+            "ORDER BY w.createdAt DESC")
+    Page<WorkReport> findBySiteIdWithManagerByYearMonth(
+            @Param("siteId") Long siteId,
+            @Param("year") int year,
+            @Param("month") int month,
+            Pageable pageable);
 }

--- a/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/repository/WorkReportRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -58,14 +59,14 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
      */
     @Query("SELECT DISTINCT CAST(w.createdAt AS LocalDate) FROM WorkReport w " +
             "WHERE w.site.id = :siteId " +
-            "AND YEAR(w.createdAt) = :year " +
-            "AND MONTH(w.createdAt) = :month " +
+            "AND w.createdAt >= :startDate " +
+            "AND w.createdAt < :endDate " +
             "AND w.isDeleted = false " +
             "ORDER BY CAST(w.createdAt AS LocalDate) DESC")
     List<LocalDate> findDistinctDatesBySiteIdAndYearMonth(
             @Param("siteId") Long siteId,
-            @Param("year") int year,
-            @Param("month") int month);
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
 
     /**
      * 현장별, 날짜별 작업일보 조회 (페이지네이션 지원)
@@ -103,21 +104,21 @@ public interface WorkReportRepository extends JpaRepository<WorkReport, Long> {
      * 현장별 작업일보 목록 조회 (연도/월 필터링, 페이지네이션 지원, Manager fetch join)
      *
      * @param siteId 현장 ID
-     * @param year 연도
-     * @param month 월 (1-12)
+     * @param startDate 시작 날짜 (해당 월의 1일 00:00:00)
+     * @param endDate 종료 날짜 (다음 월의 1일 00:00:00)
      * @param pageable 페이지네이션 정보
      * @return 작업일보 페이지 (createdAt 내림차순)
      */
     @Query("SELECT w FROM WorkReport w " +
             "JOIN FETCH w.manager m " +
             "WHERE w.site.id = :siteId " +
-            "AND YEAR(w.createdAt) = :year " +
-            "AND MONTH(w.createdAt) = :month " +
+            "AND w.createdAt >= :startDate " +
+            "AND w.createdAt < :endDate " +
             "AND w.isDeleted = false " +
             "ORDER BY w.createdAt DESC")
     Page<WorkReport> findBySiteIdWithManagerByYearMonth(
             @Param("siteId") Long siteId,
-            @Param("year") int year,
-            @Param("month") int month,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
             Pageable pageable);
 }

--- a/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
@@ -255,8 +255,10 @@ public class WorkReportService {
         // 작업일보 목록 조회 (Manager fetch join)
         Page<WorkReport> workReportPage;
         if (year != null && month != null) {
-            // 연도/월 필터링
-            workReportPage = workReportRepository.findBySiteIdWithManagerByYearMonth(siteId, year, month, pageable);
+            // 연도/월 필터링 - LocalDateTime 범위로 변환
+            LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0);
+            LocalDateTime endDate = startDate.plusMonths(1);
+            workReportPage = workReportRepository.findBySiteIdWithManagerByYearMonth(siteId, startDate, endDate, pageable);
         } else {
             // 전체 조회
             workReportPage = workReportRepository.findBySiteIdWithManager(siteId, pageable);

--- a/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
@@ -235,14 +235,17 @@ public class WorkReportService {
      *
      * <p>현장에 속한 작업일보 목록을 페이지네이션하여 조회합니다.</p>
      * <p>작업일자, 작성자 이름을 포함하여 반환합니다.</p>
+     * <p>연도/월 필터링 옵션을 지원합니다.</p>
      *
      * @param siteId 현장 ID
+     * @param year 연도 (선택)
+     * @param month 월 (선택, 1-12)
      * @param pageable 페이지네이션 정보
      * @return 작업일보 목록 응답
      */
-    public WorkReportListResponse getWorkReportList(Long siteId, Pageable pageable) {
-        log.info("작업일보 목록 조회: siteId={}, page={}, size={}",
-                siteId, pageable.getPageNumber(), pageable.getPageSize());
+    public WorkReportListResponse getWorkReportList(Long siteId, Integer year, Integer month, Pageable pageable) {
+        log.info("작업일보 목록 조회: siteId={}, year={}, month={}, page={}, size={}",
+                siteId, year, month, pageable.getPageNumber(), pageable.getPageSize());
 
         // 현장 존재 여부 확인
         if (!siteRepository.existsById(siteId)) {
@@ -250,7 +253,14 @@ public class WorkReportService {
         }
 
         // 작업일보 목록 조회 (Manager fetch join)
-        Page<WorkReport> workReportPage = workReportRepository.findBySiteIdWithManager(siteId, pageable);
+        Page<WorkReport> workReportPage;
+        if (year != null && month != null) {
+            // 연도/월 필터링
+            workReportPage = workReportRepository.findBySiteIdWithManagerByYearMonth(siteId, year, month, pageable);
+        } else {
+            // 전체 조회
+            workReportPage = workReportRepository.findBySiteIdWithManager(siteId, pageable);
+        }
 
         // DTO 변환
         Page<WorkReportListResponse.WorkReportSummary> summaryPage = workReportPage.map(workReport ->

--- a/src/test/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationServiceTest.java
@@ -323,7 +323,7 @@ class SafetyEducationServiceTest {
             given(attendeeRepository.countSignedAttendees(2L)).willReturn(1L);
 
             // when
-            List<SafetyEducationLogListResponse> result = safetyEducationService.getSafetyEducationLogs(siteId, currentUserId);
+            List<SafetyEducationLogListResponse> result = safetyEducationService.getSafetyEducationLogs(siteId, null, null, currentUserId);
 
             // then
             assertThat(result).hasSize(2);

--- a/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/site/service/SiteServiceTest.java
@@ -275,7 +275,7 @@ class SiteServiceTest {
             given(workReportRepository.findBySiteIdAndDate(eq(siteId), eq(date1), any(Pageable.class))).willReturn(List.of(workReport));
 
             // when
-            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, null, null, pageable);
 
             // then
             assertThat(response).isNotNull();
@@ -323,7 +323,7 @@ class SiteServiceTest {
             given(workReportRepository.findBySiteIdAndDate(eq(siteId), eq(date1), any(Pageable.class))).willReturn(List.of());
 
             // when
-            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, null, null, pageable);
 
             // then
             assertThat(response).isNotNull();
@@ -342,7 +342,7 @@ class SiteServiceTest {
             given(siteRepository.existsById(siteId)).willReturn(false);
 
             // when & then
-            assertThatThrownBy(() -> siteService.getSafetyWorkDocuments(siteId, pageable))
+            assertThatThrownBy(() -> siteService.getSafetyWorkDocuments(siteId, null, null, pageable))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", SiteErrorCode.SITE_NOT_FOUND);
         }
@@ -359,7 +359,7 @@ class SiteServiceTest {
             given(workReportRepository.findDistinctDatesBySiteId(siteId)).willReturn(List.of());
 
             // when
-            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, pageable);
+            SafetyWorkDocumentListResponse response = siteService.getSafetyWorkDocuments(siteId, null, null, pageable);
 
             // then
             assertThat(response).isNotNull();

--- a/test-data/frontend-additional-data.sql
+++ b/test-data/frontend-additional-data.sql
@@ -1,0 +1,440 @@
+-- ============================================
+-- 프론트엔드 추가 테스트 데이터
+-- (계약, 급여, 근태, 안전교육)
+-- frontend-complete-test-data.sql 실행 후 사용
+-- ============================================
+
+USE buildup;
+
+-- ============================================
+-- 1. 계약서 5개 (FULLY_SIGNED 3개, MANAGER_SIGNING_PENDING 2개)
+-- ============================================
+
+-- frontemp001 - FULLY_SIGNED (정규직)
+INSERT INTO contracts (
+    employee_id, corporation_id, manager_id, role, contract_state,
+    employee_start_date, employee_end_date,
+    written_at, corp_signed_at, emp_signed_at,
+    emp_type, is_deleted, created_at, updated_at
+)
+SELECT
+    e.id, c.id, m.id,
+    '현장작업자',
+    'FULLY_SIGNED',
+    DATE_SUB(CURDATE(), INTERVAL 60 DAY),
+    DATE_ADD(CURDATE(), INTERVAL 305 DAY),
+    DATE_SUB(NOW(), INTERVAL 60 DAY),
+    DATE_SUB(NOW(), INTERVAL 59 DAY),
+    DATE_SUB(NOW(), INTERVAL 58 DAY),
+    'PERMANENT',
+    0,
+    NOW(),
+    NOW()
+FROM employees e
+CROSS JOIN corporations c
+CROSS JOIN managers m
+WHERE e.emp_name = '김철수'
+  AND c.corp_name = '(주)프론트테스트건설'
+  AND m.manager_name = '이현장';
+
+-- frontemp002 - FULLY_SIGNED (정규직)
+INSERT INTO contracts (
+    employee_id, corporation_id, manager_id, role, contract_state,
+    employee_start_date, employee_end_date,
+    written_at, corp_signed_at, emp_signed_at,
+    emp_type, is_deleted, created_at, updated_at
+)
+SELECT
+    e.id, c.id, m.id,
+    '안전관리자',
+    'FULLY_SIGNED',
+    DATE_SUB(CURDATE(), INTERVAL 50 DAY),
+    DATE_ADD(CURDATE(), INTERVAL 315 DAY),
+    DATE_SUB(NOW(), INTERVAL 50 DAY),
+    DATE_SUB(NOW(), INTERVAL 49 DAY),
+    DATE_SUB(NOW(), INTERVAL 48 DAY),
+    'PERMANENT',
+    0,
+    NOW(),
+    NOW()
+FROM employees e
+CROSS JOIN corporations c
+CROSS JOIN managers m
+WHERE e.emp_name = '이영희'
+  AND c.corp_name = '(주)프론트테스트건설'
+  AND m.manager_name = '이현장';
+
+-- frontemp003 - FULLY_SIGNED (정규직)
+INSERT INTO contracts (
+    employee_id, corporation_id, manager_id, role, contract_state,
+    employee_start_date, employee_end_date,
+    written_at, corp_signed_at, emp_signed_at,
+    emp_type, is_deleted, created_at, updated_at
+)
+SELECT
+    e.id, c.id, m.id,
+    '중장비 기사',
+    'FULLY_SIGNED',
+    DATE_SUB(CURDATE(), INTERVAL 40 DAY),
+    DATE_ADD(CURDATE(), INTERVAL 325 DAY),
+    DATE_SUB(NOW(), INTERVAL 40 DAY),
+    DATE_SUB(NOW(), INTERVAL 39 DAY),
+    DATE_SUB(NOW(), INTERVAL 38 DAY),
+    'PERMANENT',
+    0,
+    NOW(),
+    NOW()
+FROM employees e
+CROSS JOIN corporations c
+CROSS JOIN managers m
+WHERE e.emp_name = '박민준'
+  AND c.corp_name = '(주)프론트테스트건설'
+  AND m.manager_name = '이현장';
+
+-- frontemp004 - MANAGER_SIGNING_PENDING (일용직)
+INSERT INTO contracts (
+    employee_id, corporation_id, manager_id, role, contract_state,
+    employee_start_date, employee_end_date,
+    written_at, corp_signed_at,
+    emp_type, is_deleted, created_at, updated_at
+)
+SELECT
+    e.id, c.id, m.id,
+    '보조 작업자',
+    'MANAGER_SIGNING_PENDING',
+    CURDATE(),
+    DATE_ADD(CURDATE(), INTERVAL 90 DAY),
+    DATE_SUB(NOW(), INTERVAL 1 DAY),
+    DATE_SUB(NOW(), INTERVAL 1 DAY),
+    'DAILY',
+    0,
+    NOW(),
+    NOW()
+FROM employees e
+CROSS JOIN corporations c
+CROSS JOIN managers m
+WHERE e.emp_name = '최지은'
+  AND c.corp_name = '(주)프론트테스트건설'
+  AND m.manager_name = '이현장';
+
+-- frontemp005 - MANAGER_SIGNING_PENDING (일용직)
+INSERT INTO contracts (
+    employee_id, corporation_id, manager_id, role, contract_state,
+    employee_start_date, employee_end_date,
+    written_at, corp_signed_at,
+    emp_type, is_deleted, created_at, updated_at
+)
+SELECT
+    e.id, c.id, m.id,
+    '일용 작업자',
+    'MANAGER_SIGNING_PENDING',
+    DATE_ADD(CURDATE(), INTERVAL 3 DAY),
+    DATE_ADD(CURDATE(), INTERVAL 93 DAY),
+    NOW(),
+    NOW(),
+    'DAILY',
+    0,
+    NOW(),
+    NOW()
+FROM employees e
+CROSS JOIN corporations c
+CROSS JOIN managers m
+WHERE e.emp_name = '정서연'
+  AND c.corp_name = '(주)프론트테스트건설'
+  AND m.manager_name = '이현장';
+
+-- ============================================
+-- 2. 계약 상세 (contract_details) - 5개
+-- ============================================
+
+-- 김철수 계약 상세
+INSERT INTO contract_details (
+    contract_id, corp_name, emp_name, work_type, work_place,
+    work_start_time, work_end_time, break_start_time, break_end_time,
+    work_on_days, work_off_days,
+    pay_type, work_pay, pay_period, pay_day,
+    is_nps_applicable, is_nhi_applicable, is_eoi_applicable, is_wci_applicable,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    c.id,
+    '(주)프론트테스트건설',
+    '김철수',
+    '현장작업',
+    '강남 오피스텔 A동 신축현장',
+    '09:00:00',
+    '18:00:00',
+    '12:00:00',
+    '13:00:00',
+    '월,화,수,목,금',
+    '토,일',
+    'TRANSFER',
+    3500000,
+    'MONTHLY',
+    25,
+    1, 1, 1, 1,
+    0, NOW(), NOW()
+FROM contracts c
+CROSS JOIN employees e
+WHERE e.emp_name = '김철수'
+  AND c.employee_id = e.id;
+
+-- 이영희 계약 상세
+INSERT INTO contract_details (
+    contract_id, corp_name, emp_name, work_type, work_place,
+    work_start_time, work_end_time, break_start_time, break_end_time,
+    work_on_days, work_off_days,
+    pay_type, work_pay, pay_period, pay_day,
+    is_nps_applicable, is_nhi_applicable, is_eoi_applicable, is_wci_applicable,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    c.id,
+    '(주)프론트테스트건설',
+    '이영희',
+    '안전관리',
+    '강남 오피스텔 A동 신축현장',
+    '08:00:00',
+    '17:00:00',
+    '12:00:00',
+    '13:00:00',
+    '월,화,수,목,금',
+    '토,일',
+    'TRANSFER',
+    4000000,
+    'MONTHLY',
+    25,
+    1, 1, 1, 1,
+    0, NOW(), NOW()
+FROM contracts c
+CROSS JOIN employees e
+WHERE e.emp_name = '이영희'
+  AND c.employee_id = e.id;
+
+-- 박민준 계약 상세
+INSERT INTO contract_details (
+    contract_id, corp_name, emp_name, work_type, work_place,
+    work_start_time, work_end_time, break_start_time, break_end_time,
+    work_on_days, work_off_days,
+    pay_type, work_pay, pay_period, pay_day,
+    is_nps_applicable, is_nhi_applicable, is_eoi_applicable, is_wci_applicable,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    c.id,
+    '(주)프론트테스트건설',
+    '박민준',
+    '중장비 운전',
+    '송파 아파트 B동 리모델링',
+    '08:30:00',
+    '17:30:00',
+    '12:00:00',
+    '13:00:00',
+    '월,화,수,목,금',
+    '토,일',
+    'TRANSFER',
+    4200000,
+    'MONTHLY',
+    25,
+    1, 1, 1, 1,
+    0, NOW(), NOW()
+FROM contracts c
+CROSS JOIN employees e
+WHERE e.emp_name = '박민준'
+  AND c.employee_id = e.id;
+
+-- 최지은 계약 상세 (일용직)
+INSERT INTO contract_details (
+    contract_id, corp_name, emp_name, work_type, work_place,
+    work_start_time, work_end_time, break_start_time, break_end_time,
+    work_on_days, work_off_days,
+    pay_type, work_pay, pay_period,
+    is_nps_applicable, is_nhi_applicable, is_eoi_applicable, is_wci_applicable,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    c.id,
+    '(주)프론트테스트건설',
+    '최지은',
+    '보조작업',
+    '강남 오피스텔 A동 신축현장',
+    '09:00:00',
+    '18:00:00',
+    '12:00:00',
+    '13:00:00',
+    '월,화,수,목,금',
+    '토,일',
+    'CASH',
+    150000,
+    'DAILY',
+    1, 1, 1, 1,
+    0, NOW(), NOW()
+FROM contracts c
+CROSS JOIN employees e
+WHERE e.emp_name = '최지은'
+  AND c.employee_id = e.id;
+
+-- 정서연 계약 상세 (일용직)
+INSERT INTO contract_details (
+    contract_id, corp_name, emp_name, work_type, work_place,
+    work_start_time, work_end_time, break_start_time, break_end_time,
+    work_on_days, work_off_days,
+    pay_type, work_pay, pay_period,
+    is_nps_applicable, is_nhi_applicable, is_eoi_applicable, is_wci_applicable,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    c.id,
+    '(주)프론트테스트건설',
+    '정서연',
+    '일용작업',
+    '송파 아파트 B동 리모델링',
+    '09:00:00',
+    '17:00:00',
+    '12:00:00',
+    '13:00:00',
+    '월,화,수,목,금,토',
+    '일',
+    'CASH',
+    160000,
+    'DAILY',
+    1, 1, 1, 1,
+    0, NOW(), NOW()
+FROM contracts c
+CROSS JOIN employees e
+WHERE e.emp_name = '정서연'
+  AND c.employee_id = e.id;
+
+-- ============================================
+-- 3. 오늘 출근 기록 3개 (지각 2명)
+-- ============================================
+
+-- 김철수 - 정상 출근 (09:00)
+INSERT INTO attendance_records (
+    employee_id, site_id, attendance_type, state,
+    timestamp, captured_face_image_url, similarity_score,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    e.id,
+    s.id,
+    'CHECK_IN',
+    'CONFIRMED',
+    CONCAT(CURDATE(), ' 09:00:00'),
+    'https://example.com/faces/kim-checkin.jpg',
+    98.5,
+    0, NOW(), NOW()
+FROM employees e
+CROSS JOIN sites s
+WHERE e.emp_name = '김철수'
+  AND s.site_name LIKE '%강남%'
+LIMIT 1;
+
+-- 이영희 - 지각 (08:10, 출근시간 08:00 + 5분 초과)
+INSERT INTO attendance_records (
+    employee_id, site_id, attendance_type, state,
+    timestamp, captured_face_image_url, similarity_score,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    e.id,
+    s.id,
+    'CHECK_IN',
+    'CONFIRMED',
+    CONCAT(CURDATE(), ' 08:10:00'),
+    'https://example.com/faces/lee-checkin.jpg',
+    97.2,
+    0, NOW(), NOW()
+FROM employees e
+CROSS JOIN sites s
+WHERE e.emp_name = '이영희'
+  AND s.site_name LIKE '%강남%'
+LIMIT 1;
+
+-- 박민준 - 지각 (08:40, 출근시간 08:30 + 5분 초과)
+INSERT INTO attendance_records (
+    employee_id, site_id, attendance_type, state,
+    timestamp, captured_face_image_url, similarity_score,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    e.id,
+    s.id,
+    'CHECK_IN',
+    'CONFIRMED',
+    CONCAT(CURDATE(), ' 08:40:00'),
+    'https://example.com/faces/park-checkin.jpg',
+    96.8,
+    0, NOW(), NOW()
+FROM employees e
+CROSS JOIN sites s
+WHERE e.emp_name = '박민준'
+  AND s.site_name LIKE '%송파%'
+LIMIT 1;
+
+-- ============================================
+-- 4. 안전교육일지 2개 (MANAGER_SIGNING_PENDING)
+-- ============================================
+
+INSERT INTO safety_education_logs (
+    corporation_id, manager_id, site_id,
+    education_subject, education_content, education_location,
+    education_type, instructor_name, status,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    c.id,
+    m.id,
+    s.id,
+    '추락재해 예방 안전교육',
+    '고소작업 시 안전수칙 및 안전장비 착용 방법',
+    '강남 오피스텔 A동 현장사무실',
+    'REGULAR',
+    '이현장',
+    'MANAGER_SIGNING_PENDING',
+    0, NOW(), NOW()
+FROM corporations c
+CROSS JOIN managers m
+CROSS JOIN sites s
+WHERE c.corp_name = '(주)프론트테스트건설'
+  AND m.manager_name = '이현장'
+  AND s.site_name LIKE '%강남%'
+LIMIT 1;
+
+INSERT INTO safety_education_logs (
+    corporation_id, manager_id, site_id,
+    education_subject, education_content, education_location,
+    education_type, instructor_name, status,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    c.id,
+    m.id,
+    s.id,
+    '전기작업 안전교육',
+    '감전재해 예방 및 절연장갑 사용법',
+    '송파 아파트 B동 현장',
+    'SPECIAL',
+    '김전기',
+    'MANAGER_SIGNING_PENDING',
+    0, NOW(), NOW()
+FROM corporations c
+CROSS JOIN managers m
+CROSS JOIN sites s
+WHERE c.corp_name = '(주)프론트테스트건설'
+  AND m.manager_name = '이현장'
+  AND s.site_name LIKE '%송파%'
+LIMIT 1;
+
+-- ============================================
+-- 검증
+-- ============================================
+
+SELECT '=== 추가 데이터 주입 완료 ===' AS Status;
+SELECT COUNT(*) AS '계약서' FROM contracts WHERE is_deleted = 0;
+SELECT COUNT(*) AS '계약 상세' FROM contract_details WHERE is_deleted = 0;
+SELECT COUNT(*) AS '오늘 출근' FROM attendance_records WHERE DATE(timestamp) = CURDATE();
+SELECT COUNT(*) AS '안전교육일지' FROM safety_education_logs WHERE status = 'MANAGER_SIGNING_PENDING';
+
+SELECT '' AS '';
+SELECT '✅ 모든 API 테스트 데이터 준비 완료' AS '';

--- a/test-data/frontend-complete-test-data.sql
+++ b/test-data/frontend-complete-test-data.sql
@@ -1,0 +1,206 @@
+-- ============================================
+-- 프론트엔드 종합 테스트 데이터
+-- 생성일: 2025-01-26
+-- 목적: 모든 API 테스트가 가능한 완전한 데이터셋
+-- ============================================
+
+USE buildup;
+
+-- ============================================
+-- 1. 기업 관리자 + 기업
+-- ============================================
+-- 계정: frontcorp / Admin123!@
+
+INSERT INTO users (user_id, password, phone, email, role_id, is_deleted, profile_completed, created_at, updated_at)
+VALUES
+('frontcorp', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-1000-0001', 'frontcorp@test.com', 1, 0, 1, NOW(), NOW())
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO corporations (user_id, corp_name, corp_ceo_name, corp_address, is_deleted, created_at, updated_at)
+SELECT
+    u.id,
+    '(주)프론트테스트건설',
+    '김대표',
+    '서울특별시 강남구 테헤란로 152',
+    0,
+    NOW(),
+    NOW()
+FROM users u
+WHERE u.user_id = 'frontcorp'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+-- ============================================
+-- 2. 현장 관리자 + 현장
+-- ============================================
+-- 계정: frontmgr / Admin123!@
+
+INSERT INTO users (user_id, password, phone, email, role_id, is_deleted, profile_completed, created_at, updated_at)
+VALUES
+('frontmgr', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-2000-0001', 'frontmgr@test.com', 2, 0, 1, NOW(), NOW())
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO managers (user_id, manager_name, is_deleted, created_at, updated_at)
+SELECT
+    u.id,
+    '이현장',
+    0,
+    NOW(),
+    NOW()
+FROM users u
+WHERE u.user_id = 'frontmgr'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+-- 현장 2개 생성
+INSERT INTO sites (
+    site_name, site_address, client_name,
+    start_date, end_date,
+    manager_secret_key, employee_secret_key,
+    corporation_id, manager_id,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    '강남 오피스텔 A동 신축현장',
+    '서울특별시 강남구 역삼동 123-45',
+    '서울시설공단',
+    '2025-01-01',
+    '2025-12-31',
+    CONCAT('MGR_', SUBSTRING(MD5(CONCAT('site1', NOW())), 1, 20)),
+    CONCAT('EMP_', SUBSTRING(MD5(CONCAT('site1', NOW())), 1, 20)),
+    c.id,
+    m.id,
+    0,
+    NOW(),
+    NOW()
+FROM corporations c
+CROSS JOIN managers m
+CROSS JOIN users u_corp
+CROSS JOIN users u_mgr
+WHERE c.corp_name = '(주)프론트테스트건설'
+  AND u_corp.user_id = 'frontcorp'
+  AND c.user_id = u_corp.id
+  AND m.manager_name = '이현장'
+  AND u_mgr.user_id = 'frontmgr'
+  AND m.user_id = u_mgr.id
+LIMIT 1
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO sites (
+    site_name, site_address, client_name,
+    start_date, end_date,
+    manager_secret_key, employee_secret_key,
+    corporation_id, manager_id,
+    is_deleted, created_at, updated_at
+)
+SELECT
+    '송파 아파트 B동 리모델링',
+    '서울특별시 송파구 잠실동 456-78',
+    '대한주택공사',
+    '2025-02-01',
+    '2025-11-30',
+    CONCAT('MGR_', SUBSTRING(MD5(CONCAT('site2', NOW())), 1, 20)),
+    CONCAT('EMP_', SUBSTRING(MD5(CONCAT('site2', NOW())), 1, 20)),
+    c.id,
+    m.id,
+    0,
+    NOW(),
+    NOW()
+FROM corporations c
+CROSS JOIN managers m
+CROSS JOIN users u_corp
+CROSS JOIN users u_mgr
+WHERE c.corp_name = '(주)프론트테스트건설'
+  AND u_corp.user_id = 'frontcorp'
+  AND c.user_id = u_corp.id
+  AND m.manager_name = '이현장'
+  AND u_mgr.user_id = 'frontmgr'
+  AND m.user_id = u_mgr.id
+LIMIT 1
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+-- ============================================
+-- 3. 근로자 10명
+-- ============================================
+-- 계정: frontemp001~010 / Admin123!@
+
+INSERT INTO users (user_id, password, phone, email, role_id, is_deleted, profile_completed, created_at, updated_at)
+VALUES
+('frontemp001', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3001-0001', 'emp001@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp002', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3002-0002', 'emp002@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp003', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3003-0003', 'emp003@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp004', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3004-0004', 'emp004@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp005', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3005-0005', 'emp005@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp006', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3006-0006', 'emp006@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp007', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3007-0007', 'emp007@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp008', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3008-0008', 'emp008@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp009', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3009-0009', 'emp009@test.com', 3, 0, 1, NOW(), NOW()),
+('frontemp010', '$2a$10$d48wVDxrG/Paw.ULUn5.ae0IGrOu5415tyKW24RR5lKmqQcdgLdoy', '010-3010-0010', 'emp010@test.com', 3, 0, 1, NOW(), NOW())
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+-- 근로자 상세 정보
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '김철수', 'PERMANENT', '010-9001-0001', '서울특별시 강남구 대치동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp001'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '이영희', 'PERMANENT', '010-9002-0002', '서울특별시 송파구 잠실동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp002'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '박민준', 'PERMANENT', '010-9003-0003', '서울특별시 서초구 서초동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp003'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '최지은', 'DAILY', '010-9004-0004', '서울특별시 관악구 봉천동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp004'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '정서연', 'DAILY', '010-9005-0005', '서울특별시 강서구 화곡동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp005'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '한지민', 'DAILY', '010-9006-0006', '서울특별시 마포구 상암동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp006'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '강동원', 'PERMANENT', '010-9007-0007', '서울특별시 용산구 한남동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp007'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '송혜교', 'PERMANENT', '010-9008-0008', '서울특별시 강남구 논현동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp008'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '유재석', 'DAILY', '010-9009-0009', '서울특별시 서대문구 연희동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp009'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+INSERT INTO employees (user_id, emp_name, emp_type, sub_phone, emp_address, is_deleted, created_at, updated_at)
+SELECT u.id, '아이유', 'DAILY', '010-9010-0010', '서울특별시 영등포구 여의도동', 0, NOW(), NOW()
+FROM users u WHERE u.user_id = 'frontemp010'
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+
+-- ============================================
+-- 검증 쿼리
+-- ============================================
+
+SELECT '=== 프론트엔드 테스트 데이터 주입 완료 ===' AS Status;
+SELECT '' AS '';
+
+SELECT '📊 생성된 데이터 요약' AS '';
+SELECT COUNT(*) AS '기업 수' FROM corporations WHERE corp_name LIKE '%프론트%';
+SELECT COUNT(*) AS '현장 수' FROM sites WHERE site_name LIKE '%강남%' OR site_name LIKE '%송파%';
+SELECT COUNT(*) AS '근로자 수' FROM employees WHERE emp_name IN ('김철수', '이영희', '박민준', '최지은', '정서연', '한지민', '강동원', '송혜교', '유재석', '아이유');
+
+SELECT '' AS '';
+SELECT '🔑 테스트 계정 정보' AS '';
+SELECT '기업: frontcorp / Admin123!@' AS '';
+SELECT '관리자: frontmgr / Admin123!@' AS '';
+SELECT '근로자: frontemp001~010 / Admin123!@' AS '';


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-196](https://concrete-buildup.atlassian.net/browse/BU-196)

## 📝 변경 사항 요약

작업일보, 안전교육일지, 통합 조회 API에 연도/월별 필터링 기능을 추가했습니다.

### 주요 변경사항
- 작업일보 목록 조회 API에 year, month 파라미터 추가
- 안전교육일지 목록 조회 API에 year, month 파라미터 추가  
- 통합 조회 API(기업 관리자용)에 year, month 파라미터 추가
- Repository, Service, Controller 3개 레이어 모두 수정
- 기존 API와의 하위 호환성 유지 (파라미터 생략 시 전체 조회)

## 🎯 변경 목적

프론트엔드에서 연도/월별로 문서를 필터링하여 조회할 수 있도록 API 기능을 확장합니다.

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] Repository: YEAR(), MONTH() 함수를 사용한 날짜 필터링 쿼리 메서드 추가
- [x] Service: 연도/월 파라미터에 따른 조건부 쿼리 실행 로직 구현
- [x] Controller: year, month RequestParam 추가 및 Swagger 문서화

### 기타 변경사항 (Others)
- [x] 테스트 코드: 변경된 메서드 시그니처에 맞게 수정

## 🧪 테스트 방법

### 단위 테스트
- [x] 단위 테스트 작성 완료
- [x] 기존 테스트 통과 확인
- 테스트 커버리지: 기존 유지

### 수동 테스트
1. 작업일보 전체 조회: `GET /v1/{siteId}/work-reports?page=0&size=10`
2. 작업일보 연도/월 필터링: `GET /v1/{siteId}/work-reports?year=2025&month=11&page=0&size=10`
3. 안전교육일지 전체 조회: `GET /v1/{siteId}/safety-education-logs`
4. 안전교육일지 연도/월 필터링: `GET /v1/{siteId}/safety-education-logs?year=2025&month=11`
5. 통합 조회 전체: `GET /v1/sites/{siteId}/safety-work-documents?page=0&size=10`
6. 통합 조회 연도/월 필터링: `GET /v1/sites/{siteId}/safety-work-documents?year=2025&month=11&page=0&size=10`

### API 테스트 결과
```bash
# 1. 작업일보 전체 조회 (현장 176)
curl -X GET "http://localhost:8080/api/v1/176/work-reports?page=0&size=10" \
  -b cookies.txt

# 결과: totalElements: 12건
```

```bash
# 2. 작업일보 2025년 11월 필터링
curl -X GET "http://localhost:8080/api/v1/176/work-reports?year=2025&month=11&page=0&size=10" \
  -b cookies.txt

# 결과: totalElements: 12건 (모든 데이터가 2025년 11월)
```

```bash
# 3. 작업일보 2025년 10월 필터링 (데이터 없음)
curl -X GET "http://localhost:8080/api/v1/176/work-reports?year=2025&month=10&page=0&size=10" \
  -b cookies.txt

# 결과: totalElements: 0건 (필터링 정상 작동)
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

기존 API 호출(파라미터 없음)은 그대로 작동하며, 새로운 파라미터는 선택적입니다.

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

기존 테이블 구조를 그대로 사용하며, YEAR(), MONTH() 함수로 조회만 수행합니다.

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거 (환경변수 또는 설정 파일 사용)
- [x] 로그 레벨 적절히 설정 (DEBUG → INFO/WARN/ERROR)

### 테스트
- [x] 단위 테스트 작성 완료
- [x] 통합 테스트 작성 완료 (필요시)
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] SQL Injection 취약점 검토
- [x] XSS 취약점 검토
- [x] 인증/인가 로직 검토
- [x] 민감 정보 노출 검토 (비밀번호, API 키 등)
- [x] 입력 검증 로직 추가

### 성능
- [x] N+1 쿼리 문제 검토
- [x] 불필요한 DB 쿼리 최적화
- [x] 적절한 인덱스 사용 확인
- [x] 대용량 데이터 처리 고려

### 문서
- [x] API 문서 업데이트 (Swagger 주석)
- [x] README.md 업데이트 (필요시)
- [x] 코드 주석 작성 (복잡한 로직만)
- [x] Jira Story 상태 업데이트

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: BU-196`)
- [x] develop 브랜치 최신 코드 반영 (rebase)
- [x] 충돌 해결 완료

## 📌 리뷰어에게

- Repository 레이어에서 YEAR(), MONTH() MySQL 함수를 사용했습니다
- 파라미터가 모두 있을 때만 필터링 쿼리를 사용하도록 Service 레이어에서 조건 분기 처리했습니다
- 기존 API와의 호환성을 위해 파라미터를 Optional로 설정했습니다

[BU-196]: https://build-up-project.atlassian.net/browse/BU-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 현장 대시보드 추가 — 기본정보, 인력·안전·노무 현황 및 미정산 계약 요약 제공
  * 연도/월 필터 추가 — 안전교육, 근무보고서, 안전·근무 서류 조회에서 연도/월별 조회 지원

* **정비**
  * 데이터베이스 스키마 동기화 마이그레이션 추가 및 프론트엔드 테스트용 시드 데이터 확충

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->