### PR TITLE
fix/BU-203: 목록 조회 API에서 데이터 없을 때 500 에러 대신 빈 응답 반환 & 현장, 현장관리자 id 매핑 

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/concrete/buildup/domain/attendance/service/AttendanceService.java
@@ -88,6 +88,12 @@ public class AttendanceService {
         // 2. Site 조회 → managerId 획득
         Site site = siteRepository.findById(siteId)
             .orElseThrow(() -> new BusinessException(CommonErrorCode.RESOURCE_NOT_FOUND, "현장을 찾을 수 없습니다."));
+
+        // Manager가 없는 경우 빈 응답 반환
+        if (site.getManager() == null) {
+            log.warn("Site에 Manager가 설정되지 않음 - siteId: {}", siteId);
+            return buildEmptyResponse(page, size);
+        }
         Long managerId = site.getManager().getId();
 
         // 3. 날짜 범위 계산
@@ -938,5 +944,36 @@ public class AttendanceService {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE,
                 "S3 URL 형식이 올바르지 않습니다: " + e.getMessage());
         }
+    }
+
+    /**
+     * 빈 근태 응답 생성
+     *
+     * <p>Manager가 설정되지 않았거나 조회할 데이터가 없는 경우 빈 응답을 반환합니다.</p>
+     *
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @return 빈 근태 응답
+     */
+    private AttendanceListResponseDto buildEmptyResponse(Integer page, Integer size) {
+        AttendanceSummaryDto emptySummary = AttendanceSummaryDto.builder()
+            .normalAttendance(0L)
+            .late(0L)
+            .earlyLeave(0L)
+            .absent(0L)
+            .build();
+
+        PaginationDto pagination = PaginationDto.builder()
+            .currentPage(page)
+            .totalPages(0)
+            .totalRecords(0L)
+            .pageSize(size)
+            .build();
+
+        return AttendanceListResponseDto.builder()
+            .summary(emptySummary)
+            .records(Collections.emptyList())
+            .pagination(pagination)
+            .build();
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/concrete/buildup/domain/attendance/service/AttendanceService.java
@@ -665,6 +665,9 @@ public class AttendanceService {
         Site site = siteRepository.findById(siteId)
             .orElseThrow(() -> new BusinessException(CommonErrorCode.RESOURCE_NOT_FOUND, "현장을 찾을 수 없습니다."));
 
+        if (site.getManager() == null) {
+            throw new BusinessException(CommonErrorCode.RESOURCE_NOT_FOUND, "현장에 관리자가 설정되지 않았습니다.");
+        }
         Long managerId = site.getManager().getId();
 
         // EmpType 안전하게 변환

--- a/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
+++ b/src/main/java/com/concrete/buildup/domain/auth/service/AuthService.java
@@ -385,7 +385,12 @@ public class AuthService {
         Manager savedManager = managerRepository.save(manager);
         log.debug("Manager 저장 완료: id={}, managerName={}", savedManager.getId(), savedManager.getManagerName());
 
-        // 10. Response 생성
+        // 10. Site에 Manager 할당
+        site.assignManager(savedManager);
+        siteRepository.save(site);
+        log.debug("Site에 Manager 할당 완료: siteId={}, managerId={}", site.getId(), savedManager.getId());
+
+        // 11. Response 생성
         SignUpResponse response = buildManagerSignUpResponse(savedUser, savedManager, site);
 
         log.info("현장 관리자 회원가입 완료: userId={}, managerId={}, siteId={}",

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
@@ -285,6 +285,7 @@ public class SafetyEducationService {
         List<SafetyEducationAttendee> attendees = attendeeRepository.findBySafetyEducationLogIdWithEmployee(logId);
 
         List<AttendeeSignatureStatusResponse.AttendeeSignatureDto> attendeeDtos = attendees.stream()
+                .filter(a -> a.getEmployee() != null)
                 .map(a -> AttendeeSignatureStatusResponse.AttendeeSignatureDto.builder()
                         .employeeId(a.getEmployee().getId())
                         .empName(a.getEmployee().getEmpName())
@@ -294,12 +295,12 @@ public class SafetyEducationService {
                         .build())
                 .collect(Collectors.toList());
 
-        int signedCount = (int) attendees.stream().filter(SafetyEducationAttendee::getIsSigned).count();
-        int unsignedCount = attendees.size() - signedCount;
+        int signedCount = (int) attendeeDtos.stream().filter(AttendeeSignatureStatusResponse.AttendeeSignatureDto::getIsSigned).count();
+        int unsignedCount = attendeeDtos.size() - signedCount;
 
         return AttendeeSignatureStatusResponse.builder()
                 .safetyEducationLogId(logId)
-                .totalCount(attendees.size())
+                .totalCount(attendeeDtos.size())
                 .signedCount(signedCount)
                 .unsignedCount(unsignedCount)
                 .attendees(attendeeDtos)

--- a/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
+++ b/src/main/java/com/concrete/buildup/domain/safetydoc/service/SafetyEducationService.java
@@ -185,6 +185,7 @@ public class SafetyEducationService {
         // 참석자 정보 변환
         List<SafetyEducationAttendee> attendees = attendeeRepository.findBySafetyEducationLogIdWithEmployee(logId);
         List<SafetyEducationLogDetailResponse.AttendeeDto> attendeeDtos = attendees.stream()
+                .filter(a -> a.getEmployee() != null)
                 .map(a -> SafetyEducationLogDetailResponse.AttendeeDto.builder()
                         .employeeId(a.getEmployee().getId())
                         .empName(a.getEmployee().getEmpName())

--- a/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
+++ b/src/main/java/com/concrete/buildup/domain/workreport/service/WorkReportService.java
@@ -268,8 +268,8 @@ public class WorkReportService {
         Page<WorkReportListResponse.WorkReportSummary> summaryPage = workReportPage.map(workReport ->
                 WorkReportListResponse.WorkReportSummary.builder()
                         .workReportId(workReport.getId())
-                        .workDate(workReport.getCreatedAt().toLocalDate())
-                        .writerName(workReport.getManager().getManagerName())
+                        .workDate(workReport.getCreatedAt() != null ? workReport.getCreatedAt().toLocalDate() : null)
+                        .writerName(workReport.getManager() != null ? workReport.getManager().getManagerName() : null)
                         .build()
         );
 

--- a/src/main/java/com/concrete/buildup/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/concrete/buildup/global/exception/GlobalExceptionHandler.java
@@ -345,6 +345,19 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * IllegalArgumentException 처리
+     * 잘못된 인자값이 전달된 경우 발생하는 예외를 처리합니다.
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("[IllegalArgumentException] Invalid argument: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(e.getMessage(), "COMMON_400"));
+    }
+
+    /**
      * IllegalStateException 처리
      * 시스템 상태 오류 시 발생하는 예외를 처리합니다.
      */


### PR DESCRIPTION

# Pull Request

## 📋 Jira Issue
- Jira: [BU-203](https://buildupteam.atlassian.net/browse/BU-203)

## 📝 변경 사항 요약

### 주요 변경사항
- 근태 조회 API에서 Manager가 없는 현장 조회 시 500 에러 대신 빈 응답 반환
- IllegalArgumentException 핸들러 추가로 400 Bad Request 반환
- 작업일보/안전교육일지 목록 조회 시 NPE 방지

## 🎯 변경 목적
프론트엔드에서 데이터가 없는 현장을 조회할 때 500 에러가 발생하면 "서버 오류" 알림이 표시되는 문제 해결.
데이터가 없는 경우 200 OK와 빈 데이터를 반환하도록 수정.

**실제 에러 로그 (2025-11-27 18:08:15):**
```
java.lang.NullPointerException: Cannot invoke "Manager.getId()" 
because the return value of "Site.getManager()" is null
```

## 🔍 변경 내역 상세

### 버그 수정 (Bug Fixes)
- [x] AttendanceService: Manager null 체크 후 빈 응답 반환
- [x] AttendanceService: createAttendanceRecord에서 Manager null 체크 추가
- [x] GlobalExceptionHandler: IllegalArgumentException → 400 Bad Request 반환
- [x] WorkReportService: createdAt, manager null 체크 추가
- [x] SafetyEducationService: employee null인 참석자 필터링 추가

## 🧪 테스트 방법

### 단위 테스트
- [x] 기존 테스트 통과 확인
- `./gradlew clean build` 성공

### 수동 테스트
1. Manager가 설정되지 않은 현장 ID로 근태 조회 API 호출
2. 200 OK와 빈 데이터 반환 확인

### API 테스트 예시
```bash
# Manager가 없는 현장 조회
curl -X GET "http://localhost:8080/api/v1/{siteId}/attendance/records?year=2025&month=11&day=27&employmentType=REGULAR" \
  -H "Authorization: Bearer {토큰}"
```

**예상 결과:**
```json
{
  "success": true,
  "message": "근태 현황을 조회했습니다.",
  "data": {
    "summary": { "normalAttendance": 0, "late": 0, "earlyLeave": 0, "absent": 0 },
    "records": [],
    "pagination": { "currentPage": 1, "totalPages": 0, "totalRecords": 0, "pageSize": 20 }
  }
}
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수
- [x] 불필요한 주석 제거
- [x] 로그 레벨 적절히 설정

### 테스트
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] 입력 검증 로직 추가

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: BU-203`)

## 📌 리뷰어에게
- Manager가 null인 경우 500 에러 대신 빈 응답을 반환하도록 수정했습니다.
- 프론트엔드에서 "서버 오류" 알림 대신 정상적으로 빈 데이터를 처리할 수 있습니다.

[BU-203]: https://build-up-project.atlassian.net/browse/BU-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 근무 보고서 조회 시 날짜·작성자 누락으로 인한 오류 해결
  * 출근 기록 조회·생성 시 현장 매니저 유무 검증 강화, 매니저 없을 땐 빈 응답 또는 오류 처리
  * 안전교육 기록 조회 시 참석자 정보 널 필터링으로 안정성 개선
  * 등록 시 생성된 매니저를 현장에 명시적으로 연결하도록 개선
  * 유효하지 않은 요청에 대해 명확한 400 응답 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->