### PR TITLE
hotfix/#122: empType 파라미터 수정

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/contract/service/ContractService.java
+++ b/src/main/java/com/concrete/buildup/domain/contract/service/ContractService.java
@@ -298,7 +298,12 @@ public class ContractService {
                     .build();
         }
 
-        // ========== 2. UNCONTRACTED 근로자 별도 처리 ==========
+        // ========== 2. empType 분기 처리 ==========
+        // empType이 NULL이면 모든 유형(UNCONTRACTED + DAILY + PERMANENT) 조회
+        if (condition.getEmpType() == null) {
+            return getAllEmployeesWithContracts(siteId, managerId, condition);
+        }
+
         // UNCONTRACTED 근로자는 Contract 테이블에 레코드가 없으므로, Employee 기반으로 직접 조회
         if (condition.getEmpType() == EmpType.UNCONTRACTED) {
             return getUncontractedEmployees(siteId, condition);
@@ -306,22 +311,20 @@ public class ContractService {
 
         // ========== 3. empType 필터링 - Employee 테이블에서 해당 타입의 employeeId 목록 조회 ==========
         List<Long> employeeIdsByType = null;
-        if (condition.getEmpType() != null) {
-            // 계약된 근로자는 User.siteId 기준으로 현장 필터링
-            List<Employee> employeesByType = employeeRepository.findByEmpTypeAndSiteId(
-                    condition.getEmpType().name(), siteId);
-            log.debug("empType 필터링 완료 (siteId={}): empType={}, count={}",
-                    siteId, condition.getEmpType(), employeesByType.size());
-            
-            employeeIdsByType = employeesByType.stream()
-                    .map(Employee::getId)
-                    .toList();
+        // 계약된 근로자는 User.siteId 기준으로 현장 필터링
+        List<Employee> employeesByType = employeeRepository.findByEmpTypeAndSiteId(
+                condition.getEmpType().name(), siteId);
+        log.debug("empType 필터링 완료 (siteId={}): empType={}, count={}",
+                siteId, condition.getEmpType(), employeesByType.size());
+        
+        employeeIdsByType = employeesByType.stream()
+                .map(Employee::getId)
+                .toList();
 
-            // empType에 해당하는 근로자가 없으면 빈 목록 반환
-            if (employeeIdsByType.isEmpty()) {
-                log.info("해당 empType의 근로자가 없음: siteId={}, empType={}", siteId, condition.getEmpType());
-                return buildEmptyResponse(condition);
-            }
+        // empType에 해당하는 근로자가 없으면 빈 목록 반환
+        if (employeeIdsByType.isEmpty()) {
+            log.info("해당 empType의 근로자가 없음: siteId={}, empType={}", siteId, condition.getEmpType());
+            return buildEmptyResponse(condition);
         }
 
         // ========== 4. 동적 조건으로 Contract 조회 (페이징) ==========
@@ -437,6 +440,90 @@ public class ContractService {
 
         return ContractListResponse.builder()
                 .items(items)
+                .pageInfo(pageInfo)
+                .build();
+    }
+
+    /**
+     * 모든 유형의 근로자 조회 (UNCONTRACTED + DAILY + PERMANENT)
+     *
+     * <p>empType 파라미터가 없을 때, 계약된 근로자와 미계약 근로자를 모두 조회합니다.</p>
+     * <p>두 데이터 소스를 합쳐서 수동 페이징 처리합니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @param managerId 관리자 ID
+     * @param condition 검색 조건
+     * @return ContractListResponse - 전체 근로자 목록 + 페이징 정보
+     */
+    private ContractListResponse getAllEmployeesWithContracts(Long siteId, Long managerId, ContractSearchCondition condition) {
+        log.info("전체 근로자 목록 조회 (UNCONTRACTED + 계약된 근로자): siteId={}", siteId);
+
+        List<ContractSummaryDto> allItems = new java.util.ArrayList<>();
+
+        // ========== 1. 미계약 근로자(UNCONTRACTED) 조회 ==========
+        List<Employee> uncontractedEmployees = employeeRepository.findUncontractedBySiteId(siteId);
+        log.debug("미계약 근로자 조회: siteId={}, count={}", siteId, uncontractedEmployees.size());
+
+        // 미계약 근로자 DTO 변환
+        List<ContractSummaryDto> uncontractedItems = uncontractedEmployees.stream()
+                .map(this::toUncontractedSummaryDto)
+                .toList();
+        allItems.addAll(uncontractedItems);
+
+        // ========== 2. 계약된 근로자(DAILY + PERMANENT) 조회 ==========
+        // 페이징 없이 전체 조회 (수동 페이징을 위해)
+        List<Contract> contracts = contractRepository.findByManagerId(managerId, Pageable.unpaged()).getContent();
+        log.debug("계약된 근로자 조회: managerId={}, count={}", managerId, contracts.size());
+
+        if (!contracts.isEmpty()) {
+            // Employee 일괄 조회 (N+1 방지)
+            List<Long> employeeIds = contracts.stream()
+                    .map(Contract::getEmployeeId)
+                    .distinct()
+                    .toList();
+
+            Map<Long, Employee> employeeMap = employeeRepository.findAllByIdInWithUser(employeeIds).stream()
+                    .collect(Collectors.toMap(Employee::getId, e -> e));
+
+            // 계약된 근로자 DTO 변환
+            List<ContractSummaryDto> contractedItems = contracts.stream()
+                    .map(contract -> toSummaryDto(contract, employeeMap.get(contract.getEmployeeId())))
+                    .toList();
+            allItems.addAll(contractedItems);
+        }
+
+        log.info("전체 근로자 조회 완료: totalCount={}", allItems.size());
+
+        // ========== 3. 수동 페이징 처리 ==========
+        int pageIndex = condition.getPageIndex();
+        int pageSize = condition.getSize();
+        int totalElements = allItems.size();
+        int totalPages = (int) Math.ceil((double) totalElements / pageSize);
+
+        int startIndex = pageIndex * pageSize;
+        int endIndex = Math.min(startIndex + pageSize, totalElements);
+
+        // 범위 벗어나면 빈 목록 반환
+        if (startIndex >= totalElements) {
+            return buildEmptyResponse(condition);
+        }
+
+        List<ContractSummaryDto> pagedItems = allItems.subList(startIndex, endIndex);
+
+        // PageInfo 생성
+        ContractListResponse.PageInfo pageInfo = ContractListResponse.PageInfo.builder()
+                .currentPage(condition.getPage())
+                .pageSize(pageSize)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .hasNext(pageIndex < totalPages - 1)
+                .hasPrevious(pageIndex > 0)
+                .build();
+
+        log.info("전체 근로자 목록 조회 완료: pagedItemCount={}", pagedItems.size());
+
+        return ContractListResponse.builder()
+                .items(pagedItems)
                 .pageInfo(pageInfo)
                 .build();
     }

--- a/src/main/java/com/concrete/buildup/domain/contract/service/ContractService.java
+++ b/src/main/java/com/concrete/buildup/domain/contract/service/ContractService.java
@@ -34,6 +34,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -448,7 +449,8 @@ public class ContractService {
      * 모든 유형의 근로자 조회 (UNCONTRACTED + DAILY + PERMANENT)
      *
      * <p>empType 파라미터가 없을 때, 계약된 근로자와 미계약 근로자를 모두 조회합니다.</p>
-     * <p>두 데이터 소스를 합쳐서 수동 페이징 처리합니다.</p>
+     * <p>필터 조건(employeeId, status, from, to)을 적용하고, 두 데이터 소스를 합쳐서 수동 페이징 처리합니다.</p>
+     * <p>정렬 순서: UNCONTRACTED 먼저 → from(시작일) 오름차순 → to(종료일) 오름차순</p>
      *
      * @param siteId 현장 ID
      * @param managerId 관리자 ID
@@ -456,13 +458,22 @@ public class ContractService {
      * @return ContractListResponse - 전체 근로자 목록 + 페이징 정보
      */
     private ContractListResponse getAllEmployeesWithContracts(Long siteId, Long managerId, ContractSearchCondition condition) {
-        log.info("전체 근로자 목록 조회 (UNCONTRACTED + 계약된 근로자): siteId={}", siteId);
+        log.info("전체 근로자 목록 조회 (UNCONTRACTED + 계약된 근로자): siteId={}, condition={}", siteId, condition);
 
         List<ContractSummaryDto> allItems = new java.util.ArrayList<>();
 
         // ========== 1. 미계약 근로자(UNCONTRACTED) 조회 ==========
+        // 미계약 근로자는 status, from, to 필터가 적용되지 않음 (계약이 없으므로)
+        // employeeId 필터만 적용
         List<Employee> uncontractedEmployees = employeeRepository.findUncontractedBySiteId(siteId);
         log.debug("미계약 근로자 조회: siteId={}, count={}", siteId, uncontractedEmployees.size());
+
+        // employeeId 필터 적용 (미계약 근로자)
+        if (condition.getEmployeeId() != null) {
+            uncontractedEmployees = uncontractedEmployees.stream()
+                    .filter(e -> e.getId().equals(condition.getEmployeeId()))
+                    .toList();
+        }
 
         // 미계약 근로자 DTO 변환
         List<ContractSummaryDto> uncontractedItems = uncontractedEmployees.stream()
@@ -471,9 +482,18 @@ public class ContractService {
         allItems.addAll(uncontractedItems);
 
         // ========== 2. 계약된 근로자(DAILY + PERMANENT) 조회 ==========
-        // 페이징 없이 전체 조회 (수동 페이징을 위해)
-        List<Contract> contracts = contractRepository.findByManagerId(managerId, Pageable.unpaged()).getContent();
-        log.debug("계약된 근로자 조회: managerId={}, count={}", managerId, contracts.size());
+        // 필터 조건(employeeId, status, from, to)을 적용하여 조회
+        Page<Contract> contractPage = contractRepository.findByDynamicConditions(
+                managerId,
+                condition.getEmployeeId(),
+                null, // employeeIdsByType - 전체 조회이므로 null
+                condition.getStatus(),
+                condition.getFrom(),
+                condition.getTo(),
+                Pageable.unpaged()
+        );
+        List<Contract> contracts = contractPage.getContent();
+        log.debug("계약된 근로자 조회 (필터 적용): managerId={}, count={}", managerId, contracts.size());
 
         if (!contracts.isEmpty()) {
             // Employee 일괄 조회 (N+1 방지)
@@ -492,9 +512,35 @@ public class ContractService {
             allItems.addAll(contractedItems);
         }
 
-        log.info("전체 근로자 조회 완료: totalCount={}", allItems.size());
+        log.info("전체 근로자 조회 완료 (필터 적용 후): totalCount={}", allItems.size());
 
-        // ========== 3. 수동 페이징 처리 ==========
+        // ========== 3. 정렬: UNCONTRACTED 먼저 → from 오름차순 → to 오름차순 ==========
+        allItems.sort((a, b) -> {
+            // 1순위: UNCONTRACTED(empType == UNCONTRACTED)가 먼저
+            boolean aIsUncontracted = a.getEmpType() == EmpType.UNCONTRACTED;
+            boolean bIsUncontracted = b.getEmpType() == EmpType.UNCONTRACTED;
+            if (aIsUncontracted && !bIsUncontracted) return -1;
+            if (!aIsUncontracted && bIsUncontracted) return 1;
+
+            // 2순위: from(employeeStartDate) 오름차순 (null은 맨 뒤)
+            LocalDate aFrom = a.getEmployeeStartDate();
+            LocalDate bFrom = b.getEmployeeStartDate();
+            if (aFrom == null && bFrom == null) return 0;
+            if (aFrom == null) return 1;
+            if (bFrom == null) return -1;
+            int fromCompare = aFrom.compareTo(bFrom);
+            if (fromCompare != 0) return fromCompare;
+
+            // 3순위: to(employeeEndDate) 오름차순 (null은 맨 뒤)
+            LocalDate aTo = a.getEmployeeEndDate();
+            LocalDate bTo = b.getEmployeeEndDate();
+            if (aTo == null && bTo == null) return 0;
+            if (aTo == null) return 1;
+            if (bTo == null) return -1;
+            return aTo.compareTo(bTo);
+        });
+
+        // ========== 4. 수동 페이징 처리 ==========
         int pageIndex = condition.getPageIndex();
         int pageSize = condition.getSize();
         int totalElements = allItems.size();

--- a/src/test/java/com/concrete/buildup/domain/contract/service/ContractServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/contract/service/ContractServiceTest.java
@@ -705,8 +705,16 @@ class ContractServiceTest {
         given(siteRepository.findById(siteId)).willReturn(Optional.of(site));
         // 미계약 근로자 조회 (getAllEmployeesWithContracts에서 호출)
         given(employeeRepository.findUncontractedBySiteId(siteId)).willReturn(List.of(uncontractedEmployee));
-        // 계약된 근로자 조회 (getAllEmployeesWithContracts에서 호출)
-        given(contractRepository.findByManagerId(eq(managerId), any(Pageable.class))).willReturn(contractPage);
+        // 계약된 근로자 조회 - findByDynamicConditions 사용 (필터 조건 적용)
+        given(contractRepository.findByDynamicConditions(
+                eq(managerId),
+                eq(null),  // employeeId
+                eq(null),  // employeeIdsByType
+                eq(null),  // status
+                eq(null),  // from
+                eq(null),  // to
+                any(Pageable.class)
+        )).willReturn(contractPage);
         given(employeeRepository.findAllByIdInWithUser(List.of(1L, 2L))).willReturn(List.of(employee1, employee2));
 
         // when
@@ -719,15 +727,33 @@ class ContractServiceTest {
         assertThat(response.getPageInfo().getCurrentPage()).isEqualTo(1);
         assertThat(response.getPageInfo().getTotalElements()).isEqualTo(3);
 
+        // 정렬: UNCONTRACTED 먼저 → from 오름차순 → to 오름차순
         // 미계약 근로자가 먼저 나옴
         ContractSummaryDto uncontractedItem = response.getItems().get(0);
         assertThat(uncontractedItem.getEmployeeName()).isEqualTo("박미계약");
         assertThat(uncontractedItem.getEmpType()).isEqualTo(EmpType.UNCONTRACTED);
         assertThat(uncontractedItem.getContractId()).isNull();
 
+        // 그 다음 from이 빠른 순 (2024-01-01 < 2024-03-01)
+        ContractSummaryDto secondItem = response.getItems().get(1);
+        assertThat(secondItem.getEmployeeName()).isEqualTo("홍길동");
+        assertThat(secondItem.getEmployeeStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+
+        ContractSummaryDto thirdItem = response.getItems().get(2);
+        assertThat(thirdItem.getEmployeeName()).isEqualTo("김철수");
+        assertThat(thirdItem.getEmployeeStartDate()).isEqualTo(LocalDate.of(2024, 3, 1));
+
         verify(siteRepository).findById(siteId);
         verify(employeeRepository).findUncontractedBySiteId(siteId);
-        verify(contractRepository).findByManagerId(eq(managerId), any(Pageable.class));
+        verify(contractRepository).findByDynamicConditions(
+                eq(managerId),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                any(Pageable.class)
+        );
     }
 
     @Test

--- a/src/test/java/com/concrete/buildup/domain/contract/service/ContractServiceTest.java
+++ b/src/test/java/com/concrete/buildup/domain/contract/service/ContractServiceTest.java
@@ -677,7 +677,7 @@ class ContractServiceTest {
     // ========== getContracts 테스트 ==========
 
     @Test
-    @DisplayName("계약 목록 조회 성공 - 필터링 없음")
+    @DisplayName("계약 목록 조회 성공 - 필터링 없음 (모든 유형 조회)")
     void getContracts_Success_NoFilter() {
         // given
         Long siteId = 1L;
@@ -690,6 +690,10 @@ class ContractServiceTest {
                 .size(20)
                 .build();
 
+        // 미계약 근로자
+        Employee uncontractedEmployee = createEmployeeWithResidentNum(3L, "박미계약", "990303-3456789", null);
+        
+        // 계약된 근로자
         Employee employee1 = createEmployeeWithResidentNum(1L, "홍길동", "950101-1234567", "PERMANENT");
         Employee employee2 = createEmployeeWithResidentNum(2L, "김철수", "880215-2345678", "DAILY");
 
@@ -699,15 +703,10 @@ class ContractServiceTest {
         Page<Contract> contractPage = new PageImpl<>(List.of(contract1, contract2));
 
         given(siteRepository.findById(siteId)).willReturn(Optional.of(site));
-        given(contractRepository.findByDynamicConditions(
-                eq(managerId),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                any(Pageable.class)
-        )).willReturn(contractPage);
+        // 미계약 근로자 조회 (getAllEmployeesWithContracts에서 호출)
+        given(employeeRepository.findUncontractedBySiteId(siteId)).willReturn(List.of(uncontractedEmployee));
+        // 계약된 근로자 조회 (getAllEmployeesWithContracts에서 호출)
+        given(contractRepository.findByManagerId(eq(managerId), any(Pageable.class))).willReturn(contractPage);
         given(employeeRepository.findAllByIdInWithUser(List.of(1L, 2L))).willReturn(List.of(employee1, employee2));
 
         // when
@@ -715,30 +714,24 @@ class ContractServiceTest {
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.getItems()).hasSize(2);
+        // 미계약 1명 + 계약 2명 = 3명
+        assertThat(response.getItems()).hasSize(3);
         assertThat(response.getPageInfo().getCurrentPage()).isEqualTo(1);
-        assertThat(response.getPageInfo().getTotalElements()).isEqualTo(2);
+        assertThat(response.getPageInfo().getTotalElements()).isEqualTo(3);
 
-        // 주민번호 마스킹 검증
-        ContractSummaryDto firstItem = response.getItems().get(0);
-        assertThat(firstItem.getEmployeeResidentNumber()).isEqualTo("950101-1******");
-        assertThat(firstItem.getEmployeeName()).isEqualTo("홍길동");
+        // 미계약 근로자가 먼저 나옴
+        ContractSummaryDto uncontractedItem = response.getItems().get(0);
+        assertThat(uncontractedItem.getEmployeeName()).isEqualTo("박미계약");
+        assertThat(uncontractedItem.getEmpType()).isEqualTo(EmpType.UNCONTRACTED);
+        assertThat(uncontractedItem.getContractId()).isNull();
 
         verify(siteRepository).findById(siteId);
-        verify(contractRepository).findByDynamicConditions(
-                eq(managerId),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                any(Pageable.class)
-        );
-        verify(employeeRepository).findAllByIdInWithUser(List.of(1L, 2L));
+        verify(employeeRepository).findUncontractedBySiteId(siteId);
+        verify(contractRepository).findByManagerId(eq(managerId), any(Pageable.class));
     }
 
     @Test
-    @DisplayName("계약 목록 조회 성공 - employeeId 필터")
+    @DisplayName("계약 목록 조회 성공 - employeeId 필터 (empType과 함께)")
     void getContracts_Success_FilterByEmployeeId() {
         // given
         Long siteId = 1L;
@@ -746,7 +739,9 @@ class ContractServiceTest {
         Manager manager = createManager(managerId, "김관리");
         Site site = createSite(siteId, "테스트현장", manager);
 
+        // employeeId 필터는 계약된 근로자를 조회하므로 empType 지정
         ContractSearchCondition condition = ContractSearchCondition.builder()
+                .empType(EmpType.PERMANENT)
                 .employeeId(1L)
                 .page(1)
                 .size(20)
@@ -759,10 +754,12 @@ class ContractServiceTest {
         Page<Contract> contractPage = new PageImpl<>(List.of(contract1));
 
         given(siteRepository.findById(siteId)).willReturn(Optional.of(site));
+        // empType 필터를 위해 Employee 조회 (siteId 기반)
+        given(employeeRepository.findByEmpTypeAndSiteId("PERMANENT", siteId)).willReturn(List.of(employee1));
         given(contractRepository.findByDynamicConditions(
                 eq(managerId),
                 eq(1L),
-                eq(null),
+                eq(List.of(1L)),
                 eq(null),
                 eq(null),
                 eq(null),
@@ -827,7 +824,7 @@ class ContractServiceTest {
     }
 
     @Test
-    @DisplayName("계약 목록 조회 성공 - status 필터")
+    @DisplayName("계약 목록 조회 성공 - status 필터 (empType과 함께)")
     void getContracts_Success_FilterByStatus() {
         // given
         Long siteId = 1L;
@@ -835,7 +832,9 @@ class ContractServiceTest {
         Manager manager = createManager(managerId, "김관리");
         Site site = createSite(siteId, "테스트현장", manager);
 
+        // status 필터는 계약된 근로자에게만 의미 있으므로 empType 지정
         ContractSearchCondition condition = ContractSearchCondition.builder()
+                .empType(EmpType.PERMANENT)
                 .status(ContractState.FULLY_SIGNED)
                 .page(1)
                 .size(20)
@@ -848,10 +847,12 @@ class ContractServiceTest {
         Page<Contract> contractPage = new PageImpl<>(List.of(contract1));
 
         given(siteRepository.findById(siteId)).willReturn(Optional.of(site));
+        // empType 필터를 위해 Employee 조회 (siteId 기반)
+        given(employeeRepository.findByEmpTypeAndSiteId("PERMANENT", siteId)).willReturn(List.of(employee1));
         given(contractRepository.findByDynamicConditions(
                 eq(managerId),
                 eq(null),
-                eq(null),
+                eq(List.of(1L)),
                 eq(ContractState.FULLY_SIGNED),
                 eq(null),
                 eq(null),
@@ -869,7 +870,7 @@ class ContractServiceTest {
     }
 
     @Test
-    @DisplayName("계약 목록 조회 성공 - 날짜 범위 필터")
+    @DisplayName("계약 목록 조회 성공 - 날짜 범위 필터 (empType과 함께)")
     void getContracts_Success_FilterByDateRange() {
         // given
         Long siteId = 1L;
@@ -880,7 +881,9 @@ class ContractServiceTest {
         LocalDate from = LocalDate.of(2024, 2, 1);
         LocalDate to = LocalDate.of(2024, 4, 1);
 
+        // 날짜 필터는 계약된 근로자에게만 의미 있으므로 empType 지정
         ContractSearchCondition condition = ContractSearchCondition.builder()
+                .empType(EmpType.DAILY)
                 .from(from)
                 .to(to)
                 .page(1)
@@ -894,10 +897,12 @@ class ContractServiceTest {
         Page<Contract> contractPage = new PageImpl<>(List.of(contract2));
 
         given(siteRepository.findById(siteId)).willReturn(Optional.of(site));
+        // empType 필터를 위해 Employee 조회 (siteId 기반)
+        given(employeeRepository.findByEmpTypeAndSiteId("DAILY", siteId)).willReturn(List.of(employee2));
         given(contractRepository.findByDynamicConditions(
                 eq(managerId),
                 eq(null),
-                eq(null),
+                eq(List.of(2L)),
                 eq(null),
                 eq(from),
                 eq(to),


### PR DESCRIPTION

# Pull Request

## 📋 Jira Issue
<!-- Jira Story/Bug 링크를 작성해주세요 -->
- Jira: [BU-XXX](https://your-jira-domain.atlassian.net/browse/BU-XXX)

## 📝 변경 사항 요약

### 주요 변경사항

- 미계약(UNCONTRACTED) 근로자를 site별로 조회할 수 있도록 Repository 메서드 추가
- N+1 쿼리 문제 해결을 위한 JOIN FETCH 메서드 추가
- JPA AttributeConverter DI 문제 해결 (ApplicationContextHolder 패턴 적용)
- 서명 좌표를 클라이언트 요청 대신 서버 고정값으로 변경
- empType 파라미터 없을 때 모든 유형(UNCONTRACTED + DAILY + PERMANENT) 근로자 조회 지원

## 🎯 변경 목적

- 프론트엔드에서 미계약 근로자 목록을 site별로 조회할 수 없는 문제 해결
- Employee 조회 시 발생하는 N+1 쿼리로 인한 성능 저하 해결
- ResidentNumConverter에서 발생하는 NullPointerException 런타임 오류 해결
- PDF 서명 좌표를 일관되게 관리하고 API 간소화
- 계약 목록 API에서 모든 근로자를 한 번에 조회할 수 있도록 개선

## 🔍 변경 내역 상세

### 추가된 기능 (Features)

- [x] 기능 1: `empType` 파라미터 없이 계약 목록 조회 시 모든 유형의 근로자(미계약 + 일용직 + 상용직) 반환
- [x] 기능 2: 미계약 근로자를 site별로 조회하는 `findUncontractedBySiteId()` Repository 메서드 추가
- [x] 기능 3: 계약된 근로자를 site별로 조회하는 `findByEmpTypeAndSiteId()` Repository 메서드 추가

### 버그 수정 (Bug Fixes)

- [x] 버그 1: `ResidentNumConverter`에서 `AesEncryptionUtil` DI 실패로 인한 NullPointerException 수정
- [x] 버그 2: Employee 조회 시 User 엔티티에 대한 N+1 쿼리 문제 수정 (`findAllByIdInWithUser()` 메서드 사용)

### 리팩토링 (Refactoring)

- [x] 리팩토링 1: 서명 좌표를 `SignatureCoordinatesConfig`로 분리하여 서버 고정값으로 관리
- [x] 리팩토링 2: `SignatureRequest` DTO에서 coordinates 필드 제거
- [x] 리팩토링 3: `ApplicationContextHolder` 유틸리티 클래스 추가하여 정적 빈 접근 패턴 적용

### 기타 변경사항 (Others)

- [x] 변경사항 1: 관련 단위 테스트 업데이트

## 🧪 테스트 방법

### 단위 테스트

- [x] 단위 테스트 작성 완료
- [x] 기존 테스트 통과 확인 (300 tests passed)
- 테스트 커버리지: 기존 유지

### 수동 테스트

1. 단계 1: 계약 목록 API 호출 (empType 파라미터 없이)
2. 단계 2: 미계약 + 계약된 근로자가 모두 반환되는지 확인
3. 단계 3: 특정 empType으로 필터링하여 조회 확인

### API 테스트 예시 (해당하는 경우)

```bash
# 모든 유형의 근로자 조회 (empType 파라미터 없음)
curl -X GET "http://localhost:8080/api/v1/1/contracts?page=1&size=20" \
  -H "Authorization: Bearer {accessToken}"

# 미계약 근로자만 조회
curl -X GET "http://localhost:8080/api/v1/1/contracts?empType=UNCONTRACTED&page=1&size=20" \
  -H "Authorization: Bearer {accessToken}"
```

**예상 결과 (empType 없음):**

```json
{
  "success": true,
  "message": "계약 목록 조회가 완료되었습니다",
  "data": {
    "items": [
      {
        "contractId": null,
        "employeeId": 6,
        "employeeName": "김미계약",
        "empType": "UNCONTRACTED",
        "contractState": null
      },
      {
        "contractId": 1,
        "employeeId": 1,
        "employeeName": "홍길동",
        "empType": "PERMANENT",
        "contractState": "FULLY_SIGNED"
      }
    ],
    "pageInfo": {
      "currentPage": 1,
      "totalElements": 2,
      "hasNext": false
    }
  }
}
```

## ⚠️ Breaking Changes

- [ ] Breaking Changes 없음
- [x] Breaking Changes 있음 (아래 설명)

**Breaking Changes 설명:**

- `SignatureRequest` DTO에서 `coordinates` 필드 제거됨
- 관리자/근로자 서명 API 호출 시 좌표 정보를 더 이상 전달하지 않아도 됨
- 기존에 coordinates를 전달하던 클라이언트는 해당 필드를 제거해야 함

## 🔗 의존성 변경

- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경

- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질

- [x] 코드 스타일 가이드 준수 (Google Java Style)
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 하드코딩된 값 제거 (환경변수 또는 설정 파일 사용)
- [x] 로그 레벨 적절히 설정 (DEBUG → INFO/WARN/ERROR)

### 테스트

- [x] 단위 테스트 작성 완료
- [ ] 통합 테스트 작성 완료 (필요시)
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안

- [x] SQL Injection 취약점 검토 (JPQL 파라미터 바인딩 사용)
- [x] XSS 취약점 검토
- [x] 인증/인가 로직 검토
- [x] 민감 정보 노출 검토 (주민번호 마스킹 적용)
- [x] 입력 검증 로직 추가

### 성능

- [x] N+1 쿼리 문제 검토 (JOIN FETCH로 해결)
- [x] 불필요한 DB 쿼리 최적화
- [x] 적절한 인덱스 사용 확인
- [x] 대용량 데이터 처리 고려 (수동 페이징 적용)

### 문서

- [ ] API 문서 업데이트 (Swagger 주석)
- [ ] README.md 업데이트 (필요시)
- [x] 코드 주석 작성 (복잡한 로직만)
- [ ] Jira Story 상태 업데이트

### Git

- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: #122`)
- [ ] develop 브랜치 최신 코드 반영 (rebase)
- [ ] 충돌 해결 완료

## 📌 리뷰어에게

1. **`getAllEmployeesWithContracts()` 메서드**: empType이 null일 때 미계약 근로자와 계약된 근로자를 합쳐서 반환합니다. 수동 페이징을 적용했는데, 대용량 데이터 처리 시 성능 개선이 필요할 수 있습니다.

2. **`ApplicationContextHolder` 패턴**: JPA AttributeConverter에서 Spring Bean을 사용하기 위해 정적 컨텍스트 접근 방식을 사용했습니다. 더 나은 대안이 있다면 제안 부탁드립니다.

3. **응답 순서**: empType 없이 조회 시 미계약 근로자가 먼저 표시됩니다. 순서 변경이 필요하면 말씀해주세요.


## 🔗 관련 PR/Issue
<!-- 관련된 다른 PR이나 Issue가 있다면 링크해주세요 -->
- Related Issue close #122 

---

## 📚 참고 자료
<!-- 참고한 문서나 자료가 있다면 링크해주세요 -->
- [관련 문서 링크]()
- [참고 자료 링크]()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 직원 유형이 지정되지 않을 때 미계약 직원을 포함한 모든 직원이 검색결과에 누락되지 않던 문제 해결
  * 미계약 항목이 결과에서 올바르게 노출되고, 미계약 먼저 표시되도록 정렬 개선

* **개선 사항**
  * 계약 목록 통합 조회 시 정렬(미계약→계약 시작일→종료일)과 수동 페이징으로 응답 일관성 및 성능 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->