### PR TITLE
fix/BU-205: 근로계약서 작성용 기업/현장 조회 API 추가

### DIFF
--- a/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
+++ b/src/main/java/com/concrete/buildup/domain/site/controller/SiteController.java
@@ -2,6 +2,7 @@ package com.concrete.buildup.domain.site.controller;
 
 import com.concrete.buildup.domain.site.dto.DashboardResponse;
 import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentListResponse;
+import com.concrete.buildup.domain.site.dto.SiteContractInfoResponse;
 import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
 import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
 import com.concrete.buildup.domain.site.dto.SiteDetailResponse;
@@ -27,6 +28,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -381,5 +383,65 @@ public class SiteController {
         return ResponseEntity.ok(
                 ApiResponse.success(response, "대시보드 정보를 성공적으로 조회했습니다.")
         );
+    }
+
+    /**
+     * 근로계약서 작성용 기업/현장 정보 조회 API
+     *
+     * <p>현장 관리자가 근로계약서 작성 시 필요한 기업 및 현장 정보를 조회합니다.</p>
+     * <p>현재 로그인한 사용자의 현장 정보를 기반으로 기업 정보를 조회합니다.</p>
+     *
+     * @return SiteContractInfoResponse - 기업/현장 정보
+     */
+    @Operation(
+            summary = "근로계약서 작성용 기업/현장 정보 조회",
+            description = "현장 관리자가 근로계약서 작성 시 필요한 기업 및 현장 정보를 조회합니다. " +
+                    "현재 로그인한 사용자의 siteId를 기반으로 현장과 기업 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "message": "기업/현장 정보 조회가 완료되었습니다",
+                                      "data": {
+                                        "siteId": 1,
+                                        "siteName": "세종대학교 AI 센터 재개발 현장",
+                                        "siteAddress": "서울시 광진구 능동로 98",
+                                        "corporation": {
+                                          "corporationId": 1,
+                                          "corpName": "빌드업건설(주)",
+                                          "corpCeoName": "김대표",
+                                          "corpAddress": "서울시 강남구 테헤란로 123"
+                                        }
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "현장 또는 사용자를 찾을 수 없음"
+            )
+    })
+    @GetMapping("/contract-info")
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    public ResponseEntity<ApiResponse<SiteContractInfoResponse>> getContractFormInfo() {
+        String currentUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+        log.info("근로계약서 작성용 정보 조회 API 호출: userId={}", currentUserId);
+
+        SiteContractInfoResponse response = siteService.getContractFormInfo(currentUserId);
+
+        log.info("근로계약서 작성용 정보 조회 완료: siteId={}", response.getSiteId());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "기업/현장 정보 조회가 완료되었습니다"));
     }
 }

--- a/src/main/java/com/concrete/buildup/domain/site/dto/SiteContractInfoResponse.java
+++ b/src/main/java/com/concrete/buildup/domain/site/dto/SiteContractInfoResponse.java
@@ -1,0 +1,55 @@
+package com.concrete.buildup.domain.site.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 근로계약서 작성을 위한 기업/현장 정보 응답 DTO
+ *
+ * <p>현장 관리자가 근로계약서 작성 시 필요한 기업 및 현장 정보를 제공합니다.</p>
+ *
+ * @author Build-Up Team
+ * @since 1.0
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "근로계약서 작성용 기업/현장 정보 응답")
+public class SiteContractInfoResponse {
+
+    @Schema(description = "현장 ID", example = "1")
+    private Long siteId;
+
+    @Schema(description = "현장명", example = "세종대학교 AI 센터 재개발 현장")
+    private String siteName;
+
+    @Schema(description = "현장 주소", example = "서울시 광진구 능동로 98")
+    private String siteAddress;
+
+    @Schema(description = "기업 정보")
+    private CorporationInfo corporation;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "기업 정보")
+    public static class CorporationInfo {
+
+        @Schema(description = "기업 ID", example = "1")
+        private Long corporationId;
+
+        @Schema(description = "사업주 (회사명)", example = "빌드업건설(주)")
+        private String corpName;
+
+        @Schema(description = "대표자명", example = "김대표")
+        private String corpCeoName;
+
+        @Schema(description = "기업 주소", example = "서울시 강남구 테헤란로 123")
+        private String corpAddress;
+    }
+}

--- a/src/main/java/com/concrete/buildup/domain/site/repository/SiteRepository.java
+++ b/src/main/java/com/concrete/buildup/domain/site/repository/SiteRepository.java
@@ -97,4 +97,16 @@ public interface SiteRepository extends JpaRepository<Site, Long> {
      */
     @Query("SELECT s FROM Site s LEFT JOIN FETCH s.manager WHERE s.corporation.id = :corporationId AND s.isDeleted = false ORDER BY s.createdAt DESC")
     List<Site> findByCorporationIdWithManager(@Param("corporationId") Long corporationId);
+
+    /**
+     * 현장 ID로 조회 (Corporation JOIN FETCH)
+     *
+     * <p>N+1 문제 방지를 위해 Corporation을 함께 조회합니다.</p>
+     * <p>근로계약서 작성 시 기업 정보 조회에 사용됩니다.</p>
+     *
+     * @param siteId 현장 ID
+     * @return 현장 정보 (Corporation 포함)
+     */
+    @Query("SELECT s FROM Site s LEFT JOIN FETCH s.corporation WHERE s.id = :siteId")
+    Optional<Site> findByIdWithCorporation(@Param("siteId") Long siteId);
 }

--- a/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
+++ b/src/main/java/com/concrete/buildup/domain/site/service/SiteService.java
@@ -8,6 +8,7 @@ import com.concrete.buildup.domain.safetydoc.entity.SafetyEducationLog;
 import com.concrete.buildup.domain.safetydoc.repository.SafetyEducationLogRepository;
 import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentDto;
 import com.concrete.buildup.domain.site.dto.SafetyWorkDocumentListResponse;
+import com.concrete.buildup.domain.site.dto.SiteContractInfoResponse;
 import com.concrete.buildup.domain.site.dto.SiteCreateRequest;
 import com.concrete.buildup.domain.site.dto.SiteCreateResponse;
 import com.concrete.buildup.domain.site.dto.SiteDetailResponse;
@@ -283,6 +284,61 @@ public class SiteService {
                 .date(date)
                 .safetyEducationLog(safetySummary)
                 .workReport(workSummary)
+                .build();
+    }
+
+    /**
+     * 근로계약서 작성용 기업/현장 정보 조회
+     *
+     * <p>현장 관리자가 근로계약서 작성 시 필요한 기업 및 현장 정보를 조회합니다.</p>
+     * <p>User.siteId를 통해 현장을 조회하고, 해당 현장의 기업 정보를 함께 반환합니다.</p>
+     *
+     * @param currentUserId 현재 로그인한 사용자 ID (userId)
+     * @return SiteContractInfoResponse - 기업/현장 정보
+     */
+    public SiteContractInfoResponse getContractFormInfo(String currentUserId) {
+        log.info("근로계약서 작성용 정보 조회: userId={}", currentUserId);
+
+        // 1. User 조회
+        User user = userRepository.findByUserId(currentUserId)
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: userId={}", currentUserId);
+                    return new BusinessException(AuthErrorCode.USER_NOT_FOUND);
+                });
+
+        // 2. User의 siteId로 현장 조회 (Corporation 포함)
+        Long siteId = user.getSiteId();
+        if (siteId == null) {
+            log.warn("사용자에게 할당된 현장이 없음: userId={}", currentUserId);
+            throw new BusinessException(SiteErrorCode.SITE_NOT_FOUND, "할당된 현장이 없습니다.");
+        }
+
+        Site site = siteRepository.findByIdWithCorporation(siteId)
+                .orElseThrow(() -> {
+                    log.warn("현장을 찾을 수 없음: siteId={}", siteId);
+                    return new BusinessException(SiteErrorCode.SITE_NOT_FOUND);
+                });
+
+        // 3. Corporation 정보 추출
+        Corporation corporation = site.getCorporation();
+        SiteContractInfoResponse.CorporationInfo corpInfo = null;
+        if (corporation != null) {
+            corpInfo = SiteContractInfoResponse.CorporationInfo.builder()
+                    .corporationId(corporation.getId())
+                    .corpName(corporation.getCorpName())
+                    .corpCeoName(corporation.getCorpCeoName())
+                    .corpAddress(corporation.getCorpAddress())
+                    .build();
+        }
+
+        log.info("근로계약서 작성용 정보 조회 완료: siteId={}, corpName={}",
+                siteId, corporation != null ? corporation.getCorpName() : null);
+
+        return SiteContractInfoResponse.builder()
+                .siteId(site.getId())
+                .siteName(site.getSiteName())
+                .siteAddress(site.getSiteAddress())
+                .corporation(corpInfo)
                 .build();
     }
 }


### PR DESCRIPTION
# Pull Request

## 📋 Jira Issue
- Jira: [BU-205](https://buildup-team.atlassian.net/browse/BU-205)

## 📝 변경 사항 요약

### 주요 변경사항
- 대시보드 인원 현황 조회 시 `managerId` 대신 `siteId` 기반으로 변경
- 근로계약서 작성용 기업/현장 정보 조회 API 추가 (`GET /v1/sites/contract-info`)

## 🎯 변경 목적
1. 대시보드에서 근로자 수가 0으로 표시되는 버그 수정 (managerId가 null인 경우 발생)
2. 현장 관리자가 근로계약서 작성 시 필요한 기업/현장 정보를 조회할 수 있도록 API 제공

## 🔍 변경 내역 상세

### 추가된 기능 (Features)
- [x] 기능 1: `GET /v1/sites/contract-info` API - 현장 관리자가 계약서 작성 시 필요한 기업/현장 정보 조회
- [x] 기능 2: `SiteContractInfoResponse` DTO 추가

### 버그 수정 (Bug Fixes)
- [x] 버그 1: 대시보드 인원 현황(totalWorkers, permanentWorkers, dailyWorkers)이 0으로 표시되는 문제 수정
  - 원인: `managerId` 기반 조회 시 managerId가 null인 경우 빈 결과 반환
  - 해결: `User.siteId` 기반으로 현장 소속 근로자 직접 조회

### 리팩토링 (Refactoring)
- [x] `DashboardService.buildWorkforceStatus()` 메서드가 `siteId`를 활용하도록 변경

## 🧪 테스트 방법

### 단위 테스트
- [x] 기존 테스트 통과 확인

### API 테스트 예시

**1. 근로계약서 작성용 정보 조회**
```bash
curl -X GET http://localhost:8080/api/v1/sites/contract-info \
  -H "Authorization: Bearer {accessToken}"
```

**예상 결과:**
```json
{
  "success": true,
  "message": "기업/현장 정보 조회가 완료되었습니다",
  "data": {
    "siteId": 1,
    "siteName": "세종대학교 AI 센터 재개발 현장",
    "siteAddress": "서울시 광진구 능동로 98",
    "corporation": {
      "corporationId": 1,
      "corpName": "빌드업건설(주)",
      "corpCeoName": "김대표",
      "corpAddress": "서울시 강남구 테헤란로 123"
    }
  }
}
```

**2. 대시보드 조회 (인원 현황 확인)**
```bash
curl -X GET http://localhost:8080/api/v1/sites/{siteId}/dashboard \
  -H "Authorization: Bearer {accessToken}"
```

## ⚠️ Breaking Changes
- [x] Breaking Changes 없음

## 🔗 의존성 변경
- [x] 의존성 변경 없음

## 🗄️ 데이터베이스 변경
- [x] DB 변경 없음

## ✅ 체크리스트

### 코드 품질
- [x] 코드 스타일 가이드 준수
- [x] Lombok 어노테이션 적절히 사용
- [x] 불필요한 주석 제거
- [x] 로그 레벨 적절히 설정

### 테스트
- [x] 모든 테스트 통과 (`./gradlew test`)
- [x] 빌드 성공 (`./gradlew clean build`)

### 보안
- [x] 인증/인가 로직 검토 (`@PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")`)

### 성능
- [x] N+1 쿼리 문제 검토 (JPQL Fetch Join 사용)

### 문서
- [x] API 문서 업데이트 (Swagger 주석)

### Git
- [x] Conventional Commits 규칙 준수
- [x] Jira 키 포함 (`Refs: BU-205`)

[BU-205]: https://build-up-project.atlassian.net/browse/BU-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계약 양식 정보 조회 기능이 추가되었습니다. 인증된 사용자는 계약 작성 시 필요한 사업장 및 회사 정보를 조회할 수 있습니다. 해당 정보에는 사업장 ID, 이름, 주소 및 회사 정보(회사 ID, 회사명, CEO명, 회사 주소)가 포함됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->